### PR TITLE
feat: make reusable header + create common theme

### DIFF
--- a/src/assets/icons/ArrowBackFilled.tsx
+++ b/src/assets/icons/ArrowBackFilled.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PRIMARY } from 'src/theme/colors';
+
+export default function ArrowBackFilled(): JSX.Element {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z"
+        fill={PRIMARY.black}
+        fillOpacity="0.87"
+      />
+    </svg>
+  );
+}

--- a/src/assets/icons/NeedHelpIcon.tsx
+++ b/src/assets/icons/NeedHelpIcon.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { PRIMARY } from 'src/theme/colors';
+
+export default function NeedHelpIcon(): JSX.Element {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M9 5H11V7H9V5ZM9 9H11V15H9V9ZM10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM10 18C5.59 18 2 14.41 2 10C2 5.59 5.59 2 10 2C14.41 2 18 5.59 18 10C18 14.41 14.41 18 10 18Z"
+        fill={PRIMARY.main}
+      />
+    </svg>
+  );
+}

--- a/src/components/reusable/ErrorText.tsx
+++ b/src/components/reusable/ErrorText.tsx
@@ -1,0 +1,8 @@
+import { Typography, styled } from '@mui/material';
+import { TEXT_COLOR } from 'src/theme/colors';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+
+export const ErrorText = styled(Typography)(() => ({
+  color: TEXT_COLOR.error,
+  fontSize: TYPOGRAPHY.xs,
+}));

--- a/src/components/reusable/FilledButton.tsx
+++ b/src/components/reusable/FilledButton.tsx
@@ -1,0 +1,10 @@
+import { Button, styled } from '@mui/material';
+import { PRIMARY, SECONDARY } from 'src/theme/colors';
+
+export const FilledButton = styled(Button)(() => ({
+  backgroundColor: PRIMARY.main,
+  color: PRIMARY.white,
+  textTransform: 'capitalize',
+  '&:hover': { backgroundColor: PRIMARY.dark_main },
+  '&:disabled': { backgroundColor: SECONDARY.light_gray },
+}));

--- a/src/components/reusable/header/index.tsx
+++ b/src/components/reusable/header/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ArrowBackFilled from 'src/assets/icons/ArrowBackFilled';
+import NeedHelpIcon from 'src/assets/icons/NeedHelpIcon';
+import { useRouter } from 'next/router';
+import { Container, Header, Text, Link } from './styles';
+
+export default function SignUpHeader({ text }: { text: string }): JSX.Element {
+  const { back } = useRouter();
+  return (
+    <Header>
+      <Container>
+        <Link type="button" onClick={back}>
+          <ArrowBackFilled />
+        </Link>
+        <Text>{text}</Text>
+      </Container>
+      <NeedHelpIcon />
+    </Header>
+  );
+}

--- a/src/components/reusable/header/styles.ts
+++ b/src/components/reusable/header/styles.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+import { PRIMARY, SECONDARY } from 'src/theme/colors';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+
+const Header = styled.header`
+  padding: 20px 15px;
+  border-bottom: 1px solid ${SECONDARY.light_gray};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 28px;
+`;
+
+const Text = styled.p`
+  color: ${PRIMARY.black};
+  font-size: ${TYPOGRAPHY.sm}px;
+  font-weight: 500;
+  text-transform: capitalize;
+`;
+
+const Link = styled.button`
+  border: none;
+  background: none;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+export { Header, Container, Text, Link };

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,17 @@
+export const PRIMARY = {
+  navy: '#03045E',
+  info: '#0DE1DD',
+  main: '#08BCB8',
+  dark_main: '#089C99',
+  white: '#fff',
+  black: '#000',
+};
+
+export const SECONDARY = {
+  light_gray: 'rgba(0, 0, 0, 0.12)',
+  md_gray: '#555555',
+};
+
+export const TEXT_COLOR = {
+  error: '#C62828',
+};

--- a/src/theme/fonts.ts
+++ b/src/theme/fonts.ts
@@ -1,0 +1,11 @@
+export const TYPOGRAPHY = {
+  xss: 12,
+  xs: 14,
+  base: 16,
+  sm: 20,
+  md: 24,
+  lg: 34,
+  xl: 48,
+  xxl: 60,
+  xxxl: 96,
+};


### PR DESCRIPTION
## Describe your changes

- I made reusable header component for signup section and set up colors and fonts. Also, some additional reusable components were made (FilledButton, ErrorText) as well as imported icons needed for signupHeader.

![изображение_2023-11-09_191354902](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/116946245/4bb456d1-83fa-443f-9dea-1c930137dbde)


