### PR TITLE
feat: adopt first reusable header

### DIFF
--- a/src/assets/icons/CloseIcon.tsx
+++ b/src/assets/icons/CloseIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PRIMARY } from 'src/theme/colors';
+
+export default function CloseIcon(): JSX.Element {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M14 1.41L12.59 0L7 5.59L1.41 0L0 1.41L5.59 7L0 12.59L1.41 14L7 8.41L12.59 14L14 12.59L8.41 7L14 1.41Z"
+        fill={PRIMARY.black}
+        fillOpacity="0.87"
+      />
+    </svg>
+  );
+}

--- a/src/components/reset-password-form/ResetPasswordForm.tsx
+++ b/src/components/reset-password-form/ResetPasswordForm.tsx
@@ -20,7 +20,10 @@ export default function ResetPasswordForm({
 }): JSX.Element {
   const { translate } = useLocales();
   const resetPassSchema = useResetPassword();
-  const [isVisible, setIsVisible] = useState<boolean>(false);
+
+  const [isPassVisible, setIsPassVisible] = useState<boolean>(false);
+  const [isConfirmPassVisible, setIsConfirmPassVisible] = useState<boolean>(false);
+
   const [resetPassword, { isLoading }] = useResetPasswordMutation();
   const [error, setError] = useState<string | null>(null);
 
@@ -34,7 +37,8 @@ export default function ResetPasswordForm({
     mode: 'onChange',
   });
 
-  const showPassword = (): void => setIsVisible((visible) => !visible);
+  const showPassword = (): void => setIsPassVisible((visible) => !visible);
+  const showConfirmPassword = (): void => setIsConfirmPassVisible((visible) => !visible);
 
   const onSubmit = handleSubmit(async (data) => {
     try {
@@ -61,21 +65,20 @@ export default function ResetPasswordForm({
             id="password"
             autoComplete="off"
             error={!!errors.password}
-            type={isVisible ? 'text' : 'password'}
+            type={isPassVisible ? 'text' : 'password'}
             endAdornment={
               <InputAdornment position="end">
                 <IconButton
                   aria-label={translate('reset_password.aria.toggle')}
                   onClick={showPassword}
                 >
-                  {isVisible ? <Visibility /> : <VisibilityOff />}
+                  {isPassVisible ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
             }
           />
           {errors?.password && <ErrorMessage>{errors.password?.message}</ErrorMessage>}
         </FormControl>
-
         <FormControl variant="outlined">
           <OutlinedInput
             size="small"
@@ -85,14 +88,14 @@ export default function ResetPasswordForm({
             autoComplete="off"
             placeholder={translate('reset_password.placeholder.confirm_pass')}
             error={!!errors.confirmPassword}
-            type={isVisible ? 'text' : 'password'}
+            type={isConfirmPassVisible ? 'text' : 'password'}
             endAdornment={
               <InputAdornment position="end">
                 <IconButton
                   aria-label={translate('reset_password.aria.toggle')}
-                  onClick={showPassword}
+                  onClick={showConfirmPassword}
                 >
-                  {isVisible ? <Visibility /> : <VisibilityOff />}
+                  {isConfirmPassVisible ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
             }

--- a/src/components/reusable/header/FlowHeader.tsx
+++ b/src/components/reusable/header/FlowHeader.tsx
@@ -3,7 +3,7 @@ import ArrowBackFilled from 'src/assets/icons/ArrowBackFilled';
 import NeedHelpIcon from 'src/assets/icons/NeedHelpIcon';
 import NeedHelpModal from 'src/components/modal-need-help/NeedHelpModal';
 import CloseIcon from 'src/assets/icons/CloseIcon';
-import { Container, Header, Text, Link, InfoButton } from './styles';
+import { Container, Header, Text, InfoButton, Icon } from './styles';
 
 enum IconType {
   close = 'close',
@@ -33,9 +33,9 @@ export default function FlowHeader({
     <>
       <Header>
         <Container>
-          <Link type="button" onClick={callback}>
+          <Icon type="button" onClick={callback}>
             {iconType === IconType.back ? <ArrowBackFilled /> : <CloseIcon />}
-          </Link>
+          </Icon>
           <Text>{text}</Text>
         </Container>
         <InfoButton type="button" onClick={handleClick}>

--- a/src/components/reusable/header/FlowHeader.tsx
+++ b/src/components/reusable/header/FlowHeader.tsx
@@ -2,13 +2,21 @@ import React, { useState } from 'react';
 import ArrowBackFilled from 'src/assets/icons/ArrowBackFilled';
 import NeedHelpIcon from 'src/assets/icons/NeedHelpIcon';
 import NeedHelpModal from 'src/components/modal-need-help/NeedHelpModal';
+import CloseIcon from 'src/assets/icons/CloseIcon';
 import { Container, Header, Text, Link, InfoButton } from './styles';
 
-export default function SignUpHeader({
+enum IconType {
+  close = 'close',
+  back = 'back',
+}
+
+export default function FlowHeader({
   text,
+  iconType,
   callback,
 }: {
   text: string;
+  iconType: 'back' | 'close';
   callback: () => void;
 }): JSX.Element {
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -26,7 +34,7 @@ export default function SignUpHeader({
       <Header>
         <Container>
           <Link type="button" onClick={callback}>
-            <ArrowBackFilled />
+            {iconType === IconType.back ? <ArrowBackFilled /> : <CloseIcon />}
           </Link>
           <Text>{text}</Text>
         </Container>

--- a/src/components/reusable/header/styles.ts
+++ b/src/components/reusable/header/styles.ts
@@ -23,7 +23,7 @@ const Text = styled.p`
   text-transform: capitalize;
 `;
 
-const Link = styled.button`
+const Icon = styled.button`
   border: none;
   background: none;
   display: flex;
@@ -45,4 +45,4 @@ const InfoButton = styled.button`
   cursor: pointer;
 `;
 
-export { Header, Container, Text, Link, InfoButton };
+export { Header, Container, Text, Icon, InfoButton };

--- a/src/components/reusable/index.tsx
+++ b/src/components/reusable/index.tsx
@@ -1,0 +1,2 @@
+export * from './ErrorText';
+export * from './FilledButton';

--- a/src/components/verification/OTPInput.tsx
+++ b/src/components/verification/OTPInput.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction, useState } from 'react';
-import { TextInput } from './styles';
+import { OtpContainer, TextInput } from './styles';
 
 type Props = {
   length: number;
@@ -48,7 +48,7 @@ export default function OTPInput({
   }
 
   return (
-    <>
+    <OtpContainer>
       {otpValues.map((_, index) => (
         <TextInput
           key={index}
@@ -61,6 +61,6 @@ export default function OTPInput({
           inputProps={{ maxLength: 1, style: { textAlign: 'center' } }}
         />
       ))}
-    </>
+    </OtpContainer>
   );
 }

--- a/src/components/verification/Verification.tsx
+++ b/src/components/verification/Verification.tsx
@@ -1,22 +1,21 @@
 import { useState } from 'react';
+import { Alert, Snackbar } from '@mui/material';
+
 import { useLocales } from 'src/locales';
 import { useRequestResetCodeMutation, useVerifyResetCodeMutation } from 'src/redux/api/authApi';
-
-import { Alert, Snackbar } from '@mui/material';
 import EmailInboxIcon from 'src/assets/icons/EmailInboxIcon';
-import { FilledButton } from '../reusable/FilledButton';
+import { ErrorText, FilledButton } from '../reusable';
 import {
   BtnContainer,
-  TextInputContainer as CodeInputWrapper,
   Container,
   FormWrapper,
   IconWrapper,
+  OtpWrapper,
   Text,
   TextBtn,
 } from './styles';
 import OTPInput from './OTPInput';
 import { OTP_LENGTH } from './constants';
-import { ErrorText } from '../reusable/ErrorText';
 
 type VerificationProps = { userEmail: string; next: () => void; back: () => void };
 
@@ -77,7 +76,7 @@ export default function Verification({ userEmail, next, back }: VerificationProp
       </IconWrapper>
       <Text>{translate('reset_password.sent_code')}</Text>
       <FormWrapper onSubmit={onSubmit}>
-        <CodeInputWrapper>
+        <OtpWrapper>
           <OTPInput
             length={length}
             setCode={setCode}
@@ -85,7 +84,8 @@ export default function Verification({ userEmail, next, back }: VerificationProp
             error={error}
             setError={setError}
           />
-        </CodeInputWrapper>
+          {error && <ErrorText>{translate('reset_password.errors.invalid_code')}</ErrorText>}
+        </OtpWrapper>
         <BtnContainer>
           <TextBtn onClick={(): Promise<void> => requestNewCode(userEmail)} disableRipple>
             {translate('request_code')}

--- a/src/components/verification/styles.ts
+++ b/src/components/verification/styles.ts
@@ -11,6 +11,18 @@ const Container = styled.div`
   gap: 48px;
 `;
 
+const OtpContainer = styled.div`
+  display: flex;
+  gap: 16px;
+`;
+
+const OtpWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+`;
+
 const IconWrapper = styled.div`
   background: ${PRIMARY.light_main};
   width: fit-content;
@@ -52,10 +64,6 @@ const TextWrapper = styled.div`
   gap: 4px;
 `;
 
-const TextInputContainer = styled.div`
-  display: flex;
-  gap: 16px;
-`;
 const TextInput = styled(TextField)(() => ({
   width: '88px',
   textAlign: 'center',
@@ -94,7 +102,8 @@ export {
   TextBtn,
   TextInput,
   TextWrapper,
-  TextInputContainer,
+  OtpContainer,
+  OtpWrapper,
   BtnContainer,
   FormWrapper,
 };

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -33,6 +33,7 @@ const en = {
       invalid: 'Enter valid email',
       invalid_pass: 'Password should contain at least {{num}} characters',
       unexpected: 'Something went wrong..',
+      invalid_code: "Entered code doesn't match the code which was sent to your email.",
     },
   },
 };


### PR DESCRIPTION
## Describe your changes

- I adopted the reusable header which we have to suit project's further needs.  Now, there is an option for 'back' icon and 'close' icon. Also, MainHeader component will be made in the near future which will contain user icon, logo and appointments.

![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/116946245/ffe9a0d4-0c14-4210-b7d3-7fe5404df5a0)
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/116946245/1921ae9f-dbee-4e40-b932-992a90f5334e)


### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [ ] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [ ] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.


