### PR TITLE
feat: compete profile 5 FE

### DIFF
--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -1,4 +1,5 @@
 import { MAX_APPOINTMENT_NAME_LENGTH } from 'src/components/create-appointment/constants';
+import { MAX_RATE, MIN_RATE } from 'src/components/complete-profile-fifth/constants';
 
 const en = {
   app_title: 'App title',
@@ -167,8 +168,8 @@ const en = {
   },
   completeProfileFifth: {
     placeholderRate: 'Rate ($/h)',
-    minRateError: 'minimal value is 1 $/h',
-    maxRateError: 'maximal value is 200 $/h',
+    minRateError: `value must be more than ${MIN_RATE} $/h`,
+    maxRateError: `maximal value is ${MAX_RATE} $/h`,
     rateRequired: 'rate is required',
   },
   create_appointment: {


### PR DESCRIPTION
## Describe your changes

create Complete profile fifth component
update error messages

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/AC-73l)
<img width="293" alt="Снимок экрана 2023-11-23 134328" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/803c5873-9a24-476f-8058-7d3d6e48d708">
<img width="302" alt="Снимок экрана 2023-11-23 134337" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/a326b096-186b-4717-aa71-57f300579025">
<img width="268" alt="Снимок экрана 2023-11-24 130148" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/6a72ceeb-df27-4ca4-9733-5f24a0e8e9ed">
<img width="310" alt="Снимок экрана 2023-11-23 141437" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/bb28a7c4-dca5-493f-9bb9-fd615e30ecf2">


### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
