### PR TITLE
fix: change password field logic

### DIFF
--- a/src/components/sign-up-fourth/index.tsx
+++ b/src/components/sign-up-fourth/index.tsx
@@ -5,90 +5,83 @@ import { useForm } from 'react-hook-form';
 import Visibility from 'src/assets/icons/Visibility';
 import VisibilityOff from 'src/assets/icons/VisibilityOff';
 import { useLocales } from 'src/locales';
-import { InferType } from 'yup';
-import { AuthFormWrapper, ErrorMessage, NextButton, StyledForm } from './style';
-import { useSignUpFourthSchema } from './validation';
+import { ErrorMessage, NextButton, StyledForm } from './style';
+import { SignUpFourthFormValues, useSignUpFourthSchema } from './validation';
 
 interface SignUpFourthFormProps {
-  onNext?: unknown;
+  onNext: (password: string) => void;
 }
 
 export default function SignUpFourthForm({ onNext }: SignUpFourthFormProps): JSX.Element {
   const { translate } = useLocales();
 
   const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState<boolean>(false);
 
-  const handleClickShowPassword = (): void => setShowPassword((show) => !show);
   const signUpFourthSchema = useSignUpFourthSchema();
-
-  type FormValues = InferType<typeof signUpFourthSchema>;
 
   const {
     register,
     handleSubmit,
-
     formState: { errors, isValid },
-  } = useForm<FormValues>({
+  } = useForm<SignUpFourthFormValues>({
     resolver: yupResolver(signUpFourthSchema),
     mode: 'onBlur',
   });
 
-  const onSubmit = handleSubmit((data) => alert(`${data.password} ${data.confirmPassword}`));
+  const handleClickShowPassword = (): void => setShowPassword((show) => !show);
+  const handleClickShowConfirmPassword = (): void => setShowConfirmPassword((show) => !show);
+
+  const onSubmit = handleSubmit((data) => onNext(data.password));
 
   return (
-    <AuthFormWrapper>
-      <StyledForm onSubmit={onSubmit}>
-        <FormControl sx={{ width: '100%' }} variant="filled">
-          <InputLabel htmlFor="password">
-            {translate('signUpFourthForm.placeholderPassword')}
-          </InputLabel>
-          <FilledInput
-            {...register('password')}
-            id="password"
-            error={!!errors.password}
-            type={showPassword ? 'text' : 'password'}
-            endAdornment={
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label="toggle password visibility"
-                  onClick={handleClickShowPassword}
-                >
-                  {showPassword ? <Visibility /> : <VisibilityOff />}
-                </IconButton>
-              </InputAdornment>
-            }
-          />
-          {errors?.password && <ErrorMessage>{errors.password?.message}</ErrorMessage>}
-        </FormControl>
-        <FormControl sx={{ width: '100%' }} variant="filled">
-          <InputLabel htmlFor="confirmPassword">
-            {translate('signUpFourthForm.placeholderConfirmPassword')}
-          </InputLabel>
-          <FilledInput
-            {...register('confirmPassword')}
-            id="confirmPassword"
-            error={!!errors.confirmPassword}
-            type={showPassword ? 'text' : 'password'}
-            endAdornment={
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label="toggle password visibility"
-                  onClick={handleClickShowPassword}
-                >
-                  {showPassword ? <Visibility /> : <VisibilityOff />}
-                </IconButton>
-              </InputAdornment>
-            }
-          />
-          {errors?.confirmPassword && (
-            <ErrorMessage variant="caption">{errors.confirmPassword?.message}</ErrorMessage>
-          )}
-        </FormControl>
-
-        <NextButton variant="contained" disabled={!isValid} type="submit">
-          Next
-        </NextButton>
-      </StyledForm>
-    </AuthFormWrapper>
+    <StyledForm onSubmit={onSubmit}>
+      <FormControl sx={{ width: '100%' }} variant="filled">
+        <InputLabel htmlFor="password">
+          {translate('signUpFourthForm.placeholderPassword')}
+        </InputLabel>
+        <FilledInput
+          {...register('password')}
+          id="password"
+          error={!!errors.password}
+          type={showPassword ? 'text' : 'password'}
+          endAdornment={
+            <InputAdornment position="end">
+              <IconButton aria-label="toggle password visibility" onClick={handleClickShowPassword}>
+                {showPassword ? <Visibility /> : <VisibilityOff />}
+              </IconButton>
+            </InputAdornment>
+          }
+        />
+        {errors?.password && <ErrorMessage>{errors.password?.message}</ErrorMessage>}
+      </FormControl>
+      <FormControl sx={{ width: '100%' }} variant="filled">
+        <InputLabel htmlFor="confirmPassword">
+          {translate('signUpFourthForm.placeholderConfirmPassword')}
+        </InputLabel>
+        <FilledInput
+          {...register('confirmPassword')}
+          id="confirmPassword"
+          error={!!errors.confirmPassword}
+          type={showConfirmPassword ? 'text' : 'password'}
+          endAdornment={
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={handleClickShowConfirmPassword}
+              >
+                {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
+              </IconButton>
+            </InputAdornment>
+          }
+        />
+        {errors?.confirmPassword && (
+          <ErrorMessage variant="caption">{errors.confirmPassword?.message}</ErrorMessage>
+        )}
+      </FormControl>
+      <NextButton variant="contained" disabled={!isValid} type="submit">
+        Next
+      </NextButton>
+    </StyledForm>
   );
 }

--- a/src/components/sign-up-fourth/style.ts
+++ b/src/components/sign-up-fourth/style.ts
@@ -1,4 +1,6 @@
 import { Button, Typography, styled } from '@mui/material';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+import typography from 'src/theme/typography';
 
 export const StyledForm = styled('form')`
   height: 100%;
@@ -7,8 +9,8 @@ export const StyledForm = styled('form')`
   gap: 16px;
   width: 480px;
   margin: 0 auto;
-  font-size: 16px;
-  font-weight: 500;
+  font-size: ${TYPOGRAPHY.base}px;
+  font-weight: ${typography.fontWeightMedium};
   line-height: 1.5;
   letter-spacing: 0.15px;
 `;
@@ -20,5 +22,6 @@ export const NextButton = styled(Button)`
 
 export const ErrorMessage = styled(Typography)`
   color: ${({ theme }): string => theme.palette.error.main};
-  font-size: 12px;
+  font-size: ${TYPOGRAPHY.xss}px;
+  font-weight: ${typography.fontWeightMedium};
 `;

--- a/src/components/sign-up-fourth/style.ts
+++ b/src/components/sign-up-fourth/style.ts
@@ -1,17 +1,12 @@
 import { Button, Typography, styled } from '@mui/material';
 
-export const AuthFormWrapper = styled('div')`
-  height: 100vh;
-`;
-
 export const StyledForm = styled('form')`
-  height: calc(100vh - 48px);
+  height: 100%;
   display: flex;
   flex-direction: column;
   gap: 16px;
   width: 480px;
   margin: 0 auto;
-  padding: 24px 0;
   font-size: 16px;
   font-weight: 500;
   line-height: 1.5;

--- a/src/components/sign-up-fourth/validation.ts
+++ b/src/components/sign-up-fourth/validation.ts
@@ -1,11 +1,13 @@
 import { useLocales } from 'src/locales';
 import { AnyObject, ObjectSchema, object, ref, string } from 'yup';
 
+export type SignUpFourthFormValues = {
+  password: string;
+  confirmPassword: string;
+};
+
 export const useSignUpFourthSchema = (): ObjectSchema<
-  {
-    password: string;
-    confirmPassword: string;
-  },
+  SignUpFourthFormValues,
   AnyObject,
   {
     password: undefined;
@@ -15,15 +17,12 @@ export const useSignUpFourthSchema = (): ObjectSchema<
 > => {
   const { translate } = useLocales();
 
-  const invalidPassword: string = translate('signUpFourthForm.passwordInvalid');
-  const passwordsNotMatching: string = translate('signUpFourthForm.passwordsNotMatching');
-  const passwordRequired: string = translate('signUpFourthForm.passwordRequired');
-  const confirmPasswordRequired: string = translate('signUpFourthForm.confirmPasswordRequired');
-
   return object({
-    password: string().min(8, invalidPassword).required(passwordRequired),
+    password: string()
+      .min(8, translate('signUpFourthForm.passwordInvalid'))
+      .required(translate('signUpFourthForm.passwordRequired')),
     confirmPassword: string()
-      .oneOf([ref('password'), undefined], passwordsNotMatching)
-      .required(confirmPasswordRequired),
+      .oneOf([ref('password'), undefined], translate('signUpFourthForm.passwordsNotMatching'))
+      .required(translate('signUpFourthForm.confirmPasswordRequired')),
   });
 };


### PR DESCRIPTION
## Describe your changes
- Fixed mentioned on demo issue with password field on fourth step of sign-up process.
## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/AC-7?atlOrigin=eyJpIjoiYjkzMzI3OTgwNTgzNDlmZGFkZDU1YTNiNzBkNmNjZDMiLCJwIjoiaiJ9)

screenshots:
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/2eb9bdac-3eec-4b48-8cb2-a9a014f26e5a)
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/7fe1fcce-dffd-4ca0-a4a0-f726e442a455)


### **General**
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).


### Frontend
- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.