### PR TITLE
refactor: refactor time functionality

### DIFF
--- a/src/components/complete-profile-fourth/CompleteProfileFourth.tsx
+++ b/src/components/complete-profile-fourth/CompleteProfileFourth.tsx
@@ -79,9 +79,7 @@ export default function CompleteProfileFourth({ onNext }: { onNext: () => void }
           </FormControl>
         </SelectContainer>
         {invalidTimeError && (
-          <ErrorText>
-            {translate('completeProfileFourth.invalid_time', { startTime: availableFrom })}
-          </ErrorText>
+          <ErrorText>{translate('completeProfileFourth.invalid_time')}</ErrorText>
         )}
         {identicalTimeError && (
           <ErrorText> {translate('completeProfileFourth.equal_time_error')}</ErrorText>

--- a/src/components/complete-profile-fourth/CompleteProfileFourth.tsx
+++ b/src/components/complete-profile-fourth/CompleteProfileFourth.tsx
@@ -26,9 +26,8 @@ export default function CompleteProfileFourth({ onNext }: { onNext: () => void }
     chooseToTime,
     defineAvailableDays,
     invalidTimeError,
-    invalidTimeErrors,
     identicalTimeError,
-    identicalTimeErrors,
+    isButtonDisabled,
     serverError,
     setServerError,
   } = useCompleteProfileFourth(onNext);
@@ -95,15 +94,7 @@ export default function CompleteProfileFourth({ onNext }: { onNext: () => void }
         <ProfileBtn
           text={translate('btn_next')}
           onClick={defineAvailableDays}
-          disabled={
-            invalidTimeErrors.length > 0 ||
-            identicalTimeErrors.length > 0 ||
-            !daySelected ||
-            !availableFrom ||
-            !availableTo ||
-            invalidTimeError ||
-            availableFrom === availableTo
-          }
+          disabled={isButtonDisabled}
         />
       </Container>
     </Wrapper>

--- a/src/components/complete-profile-fourth/constants.ts
+++ b/src/components/complete-profile-fourth/constants.ts
@@ -1,7 +1,9 @@
 import { generateTimeWithInterval } from 'src/utils/generateTime';
 
 const MINUTES_INTERVAL = 60;
+const PLUS_HOUR = 1;
+const FIRST_ELEMENT = 0;
 
-const availableTimeOptions = generateTimeWithInterval('00:00 AM', '23:45 PM', MINUTES_INTERVAL);
+const availableTimeOptions = generateTimeWithInterval('00:00', '23:45', MINUTES_INTERVAL);
 
-export { availableTimeOptions };
+export { availableTimeOptions, PLUS_HOUR, FIRST_ELEMENT };

--- a/src/components/complete-profile-fourth/hooks.ts
+++ b/src/components/complete-profile-fourth/hooks.ts
@@ -22,6 +22,15 @@ export default function useCompleteProfileFourth(onNext: () => void): HookReturn
   const [identicalTimeErrors, setIdenticalTimeErrors] = useState<string[]>([]);
   const [serverError, setServerError] = useState<boolean>(false);
 
+  const isButtonDisabled =
+    invalidTimeErrors.length > 0 ||
+    identicalTimeErrors.length > 0 ||
+    !daySelected ||
+    !availableFrom ||
+    !availableTo ||
+    invalidTimeError ||
+    availableFrom === availableTo;
+
   useEffect(() => {
     const selectedDays = availableDays.map(({ day }) => day);
     setChosenDays(selectedDays);
@@ -168,5 +177,6 @@ export default function useCompleteProfileFourth(onNext: () => void): HookReturn
     identicalTimeErrors,
     serverError,
     setServerError,
+    isButtonDisabled,
   };
 }

--- a/src/components/complete-profile-fourth/hooks.ts
+++ b/src/components/complete-profile-fourth/hooks.ts
@@ -1,0 +1,172 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { TIMEZONE_FORMAT } from 'src/constants';
+import { daySelectedType } from 'src/constants/types';
+import { useUpdateProfileMutation } from 'src/redux/api/profileCompleteApi';
+import { chooseAvailableTime } from 'src/redux/slices/availableDaysSlice';
+import { useAppDispatch, useTypedSelector } from 'src/redux/store';
+import { FIRST_ELEMENT, PLUS_HOUR, availableTimeOptions } from './constants';
+import { HookReturnType } from './types';
+
+export default function useCompleteProfileFourth(onNext: () => void): HookReturnType {
+  const dispatch = useAppDispatch();
+  const { days: availableDays } = useTypedSelector((state) => state.availableDays);
+  const [specifyAvailability] = useUpdateProfileMutation();
+
+  const [daySelected, setDaySelected] = useState<daySelectedType | null>(null);
+  const [chosenDays, setChosenDays] = useState<string[]>([]);
+  const [availableFrom, setAvailableFrom] = useState<string>('');
+  const [availableTo, setAvailableTo] = useState<string>('');
+  const [invalidTimeError, setInvalidTimeError] = useState<boolean>(false);
+  const [invalidTimeErrors, setInvalidTimeErrors] = useState<string[]>([]);
+  const [identicalTimeError, setIdenticalTimeError] = useState<boolean>(false);
+  const [identicalTimeErrors, setIdenticalTimeErrors] = useState<string[]>([]);
+  const [serverError, setServerError] = useState<boolean>(false);
+
+  useEffect(() => {
+    const selectedDays = availableDays.map(({ day }) => day);
+    setChosenDays(selectedDays);
+  }, [availableDays]);
+
+  useEffect(() => {
+    if (daySelected && availableFrom && availableTo) {
+      dispatch(
+        chooseAvailableTime({
+          time: {
+            startTime: availableFrom,
+            endTime: availableTo,
+            day: daySelected,
+          },
+        })
+      );
+    }
+  }, [daySelected, availableFrom, availableTo, dispatch]);
+
+  const chooseDay = (selectedDay: daySelectedType): void => {
+    const dayAlreadyChosen = availableDays.find(({ day }) => day === selectedDay);
+    setDaySelected(selectedDay);
+
+    if (dayAlreadyChosen) {
+      setAvailableFrom(dayAlreadyChosen.startTime);
+      setAvailableTo(dayAlreadyChosen.endTime);
+    } else {
+      setAvailableFrom('');
+      setAvailableTo('');
+    }
+
+    if (dayAlreadyChosen && invalidTimeErrors.includes(selectedDay)) {
+      setInvalidTimeError(true);
+    } else {
+      setInvalidTimeError(false);
+    }
+
+    if (dayAlreadyChosen && identicalTimeErrors.includes(selectedDay)) {
+      setIdenticalTimeError(true);
+    } else {
+      setIdenticalTimeError(false);
+    }
+
+    const filteredDays = availableDays.map(({ day }) => day);
+    setChosenDays(filteredDays);
+
+    if (!dayAlreadyChosen) {
+      setChosenDays((prev) => [...prev, selectedDay]);
+    }
+  };
+
+  const handleErrors = (
+    condition: boolean,
+    errors: string[],
+    setError: Dispatch<SetStateAction<boolean>>,
+    setErrors: Dispatch<SetStateAction<string[]>>
+  ): void => {
+    if (condition) {
+      setError(true);
+      if (daySelected) setErrors([...errors, daySelected]);
+    } else {
+      const currentErrors = errors.filter((error) => error !== daySelected);
+      setErrors(currentErrors);
+      setError(false);
+    }
+  };
+
+  const chooseFromTime = (value: string): void => {
+    setAvailableFrom(value);
+
+    const chosenValueIndex = availableTimeOptions.indexOf(value);
+    const hourlyAdjustedValue = availableTimeOptions.slice(chosenValueIndex + PLUS_HOUR)[
+      FIRST_ELEMENT
+    ];
+
+    if (!hourlyAdjustedValue) {
+      setAvailableTo(availableTimeOptions[FIRST_ELEMENT]);
+    } else {
+      setAvailableTo(hourlyAdjustedValue);
+    }
+
+    if (availableFrom) {
+      handleErrors(
+        value > hourlyAdjustedValue,
+        invalidTimeErrors,
+        setInvalidTimeError,
+        setInvalidTimeErrors
+      );
+    }
+
+    handleErrors(
+      value === availableFrom,
+      identicalTimeErrors,
+      setIdenticalTimeError,
+      setIdenticalTimeErrors
+    );
+  };
+
+  const chooseToTime = (value: string): void => {
+    setAvailableTo(value);
+
+    handleErrors(
+      value < availableFrom,
+      invalidTimeErrors,
+      setInvalidTimeError,
+      setInvalidTimeErrors
+    );
+
+    handleErrors(
+      value === availableFrom,
+      identicalTimeErrors,
+      setIdenticalTimeError,
+      setIdenticalTimeErrors
+    );
+  };
+
+  const defineAvailableDays = async (): Promise<void> => {
+    try {
+      setServerError(false);
+      await specifyAvailability({
+        updateProfileDto: {
+          availability: [...availableDays],
+          timeZone: TIMEZONE_FORMAT,
+        },
+      }).unwrap();
+      onNext();
+    } catch (err) {
+      setServerError(true);
+    }
+  };
+
+  return {
+    daySelected,
+    chosenDays,
+    availableFrom,
+    availableTo,
+    chooseDay,
+    chooseFromTime,
+    chooseToTime,
+    defineAvailableDays,
+    invalidTimeError,
+    invalidTimeErrors,
+    identicalTimeError,
+    identicalTimeErrors,
+    serverError,
+    setServerError,
+  };
+}

--- a/src/components/complete-profile-fourth/styles.ts
+++ b/src/components/complete-profile-fourth/styles.ts
@@ -29,8 +29,14 @@ const WeekSlot = styled('div')`
   background-color: ${PRIMARY.white};
   border: 1px solid ${PRIMARY.main};
   border-radius: 50%;
-  padding: 11px 13px;
+  padding: 11px 14.5px;
   cursor: pointer;
+
+  &:nth-child(1),
+  &:nth-child(3) {
+    padding: 11px 13.5px;
+  }
+
   &.active {
     background-color: ${PRIMARY.main};
     color: ${PRIMARY.white};
@@ -44,7 +50,7 @@ const WeekSlotContainer = styled('div')`
 
 const SelectContainer = styled('div')`
   display: flex;
-  gap: 20px;
+  gap: 16px;
   margin-top: 8px;
 `;
 

--- a/src/components/complete-profile-fourth/types.ts
+++ b/src/components/complete-profile-fourth/types.ts
@@ -6,6 +6,7 @@ export type HookReturnType = {
   chosenDays: string[];
   availableFrom: string;
   availableTo: string;
+  isButtonDisabled: boolean;
   chooseDay: (selectedDay: daySelectedType) => void;
   chooseFromTime: (value: string) => void;
   chooseToTime: (value: string) => void;

--- a/src/components/complete-profile-fourth/types.ts
+++ b/src/components/complete-profile-fourth/types.ts
@@ -1,0 +1,19 @@
+import { Dispatch, SetStateAction } from 'react';
+import { daySelectedType } from 'src/constants/types';
+
+export type HookReturnType = {
+  daySelected: daySelectedType | null;
+  chosenDays: string[];
+  availableFrom: string;
+  availableTo: string;
+  chooseDay: (selectedDay: daySelectedType) => void;
+  chooseFromTime: (value: string) => void;
+  chooseToTime: (value: string) => void;
+  defineAvailableDays: () => Promise<void>;
+  invalidTimeError: boolean;
+  invalidTimeErrors: string[];
+  identicalTimeError: boolean;
+  identicalTimeErrors: string[];
+  serverError: boolean;
+  setServerError: Dispatch<SetStateAction<boolean>>;
+};

--- a/src/components/create-appointment/AppointmentScheduling.tsx
+++ b/src/components/create-appointment/AppointmentScheduling.tsx
@@ -10,7 +10,7 @@ import RecurringAppointment from './RecurringAppointment';
 import { Background } from './styles';
 import { Appointment } from './enums';
 
-export default function AppointmentScheduling(): JSX.Element {
+export default function AppointmentScheduling({ onNext }: { onNext: () => void }): JSX.Element {
   const { translate } = useLocales();
   const { appointmentType } = useTypedSelector((state) => state.appointment);
   const { modalOpen, setModalOpen, handleOpen } = useCancelAppointmentModal();
@@ -28,9 +28,9 @@ export default function AppointmentScheduling(): JSX.Element {
       />
       <Background>
         {appointmentType === Appointment.oneTime ? (
-          <OneTimeAppointment />
+          <OneTimeAppointment onNext={onNext} />
         ) : (
-          <RecurringAppointment />
+          <RecurringAppointment onNext={onNext} />
         )}
       </Background>
       <CancelAppointmentModal open={modalOpen} setOpen={setModalOpen} />

--- a/src/components/create-appointment/AppointmentType.tsx
+++ b/src/components/create-appointment/AppointmentType.tsx
@@ -6,7 +6,7 @@ import FlowHeader from 'src/components/reusable/header/FlowHeader';
 import { AppointmentType as AppointmentTypeI } from 'src/constants/types';
 import { useLocales } from 'src/locales';
 import { setAppointmentName, setAppointmentType } from 'src/redux/slices/appointmentSlice';
-import { useAppDispatch } from 'src/redux/store';
+import { useAppDispatch, useTypedSelector } from 'src/redux/store';
 import {
   CancelAppointmentModal,
   useCancelAppointmentModal,
@@ -24,13 +24,14 @@ import {
   StyledForm,
 } from './styles';
 
-export default function AppointmentType(): JSX.Element {
+export default function AppointmentType({ onNext }: { onNext: () => void }): JSX.Element {
   const { translate } = useLocales();
   const dispatch = useAppDispatch();
+  const { appointmentName, appointmentType } = useTypedSelector((state) => state.appointment);
   const { modalOpen, setModalOpen, handleOpen } = useCancelAppointmentModal();
 
-  const [name, setName] = useState<string>('');
-  const [type, setType] = useState<AppointmentTypeI>(null);
+  const [name, setName] = useState<string>(appointmentName);
+  const [type, setType] = useState<AppointmentTypeI>(appointmentType);
 
   const selectOneTime = (): void => setType(Appointment.oneTime);
   const selectRecurring = (): void => setType(Appointment.recurring);
@@ -43,6 +44,7 @@ export default function AppointmentType(): JSX.Element {
   const goNext = (): void => {
     dispatch(setAppointmentName(name));
     dispatch(setAppointmentType(type));
+    onNext();
   };
 
   return (

--- a/src/components/create-appointment/OneTimeAppointment.tsx
+++ b/src/components/create-appointment/OneTimeAppointment.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, FormControl, InputLabel, MenuItem, Select, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
@@ -6,20 +6,34 @@ import OneTimeIcon from 'src/assets/icons/OneTimeIcon';
 import { FilledButton } from 'src/components/reusable';
 import { DATE_FORMAT } from 'src/constants';
 import { setOneAppointmentTime } from 'src/redux/slices/appointmentSlice';
-import { useAppDispatch } from 'src/redux/store';
+import { useAppDispatch, useTypedSelector } from 'src/redux/store';
 import { setCustomTime } from 'src/utils/defineCustomTime';
+import { extractTimeFromDate } from 'src/utils/extractTimeFromDate';
 import { selectTimeOptions } from './constants';
 import { AppointmentDuration, Container, SelectContainer } from './styles';
 import useShowDuration from './useShowDuration';
 
-export default function OneTimeAppointment(): JSX.Element {
+export default function OneTimeAppointment({ onNext }: { onNext: () => void }): JSX.Element {
   const { t: translate } = useTranslation();
   const dispatch = useAppDispatch();
+  const { oneTimeDate } = useTypedSelector((state) => state.appointment);
 
-  const [date, setDate] = useState<Date | null>(null);
+  const [date, setDate] = useState<Date | null>(oneTimeDate.startTime);
   const [startTime, setStartTime] = useState<string>('');
   const [endTime, setEndTime] = useState<string>('');
   const { hours, minutes } = useShowDuration(startTime, endTime);
+
+  useEffect(() => {
+    if (!oneTimeDate.startTime || !oneTimeDate.endTime) return;
+
+    const startDateTime = extractTimeFromDate(oneTimeDate.startTime);
+    const endDateTime = extractTimeFromDate(oneTimeDate.endTime);
+
+    if (startDateTime && endDateTime) {
+      setStartTime(startDateTime);
+      setEndTime(endDateTime);
+    }
+  }, [oneTimeDate.startTime, oneTimeDate.endTime]);
 
   const chooseStartTime = (value: string): void => setStartTime(value);
   const chooseEndTime = (value: string): void => setEndTime(value);
@@ -33,6 +47,7 @@ export default function OneTimeAppointment(): JSX.Element {
         endTime: setCustomTime(date, endTime),
       })
     );
+    onNext();
   };
 
   return (

--- a/src/components/create-appointment/constants.ts
+++ b/src/components/create-appointment/constants.ts
@@ -5,6 +5,6 @@ const MAX_APPOINTMENT_NAME_LENGTH = 50;
 const MINUTES_INTERVAL = 15;
 const ONE_DAY = 1;
 
-const selectTimeOptions = generateTimeWithInterval('00:00 AM', '23:45 PM', MINUTES_INTERVAL);
+const selectTimeOptions = generateTimeWithInterval('00:00', '23:45', MINUTES_INTERVAL);
 
 export { MIN_APPOINTMENT_NAME_LENGTH, MAX_APPOINTMENT_NAME_LENGTH, ONE_DAY, selectTimeOptions };

--- a/src/components/create-appointment/styles.ts
+++ b/src/components/create-appointment/styles.ts
@@ -114,8 +114,14 @@ const WeekSlot = styled('div')`
   background-color: ${PRIMARY.white};
   border: 1px solid ${PRIMARY.main};
   border-radius: 50%;
-  padding: 11px 13px;
+  padding: 11px 13.7px;
   cursor: pointer;
+
+  &:nth-child(1),
+  &:nth-child(3) {
+    padding: 11px 12.7px;
+  }
+
   &.active {
     background-color: ${PRIMARY.main};
     color: ${PRIMARY.white};

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -266,6 +266,8 @@ const en = {
     specify_time: ' Please specify your preferred time and your availability throughout the week',
     from: 'From',
     to: 'To',
+    invalid_time: 'Invalid time selection. Please choose a time later than {{startTime}}. ',
+    equal_time_error: 'You cannot choose identical time',
   },
   completeProfileFifth: {
     placeholderRate: 'Rate ($/h)',

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -266,7 +266,8 @@ const en = {
     specify_time: ' Please specify your preferred time and your availability throughout the week',
     from: 'From',
     to: 'To',
-    invalid_time: 'Invalid time selection. Please choose a time later than {{startTime}}. ',
+    invalid_time:
+      'Appointment cannot be ended before the start. Please choose another value in To field.',
     equal_time_error: 'You cannot choose identical time',
   },
   completeProfileFifth: {

--- a/src/utils/calculateTimeDifference.ts
+++ b/src/utils/calculateTimeDifference.ts
@@ -1,3 +1,8 @@
+// function to calculate time difference between two time values
+//  @param startTime - "10:00"
+//  @param endTime - "12:20"
+//  @return - {hours: 2, minutes: 20}
+
 export function calculateTimeDifference(
   startTime: string,
   endTime: string

--- a/src/utils/calculateTimeDifference.ts
+++ b/src/utils/calculateTimeDifference.ts
@@ -1,48 +1,24 @@
 export function calculateTimeDifference(
   startTime: string,
   endTime: string
-): {
-  hours: number;
-  minutes: number;
-} {
-  const timeRegex = /(\d{2}):(\d{2}) (AM|PM)/;
+): { hours: number; minutes: number } {
+  const [hours1, minutes1] = startTime.split(':').map(Number);
+  const [hours2, minutes2] = endTime.split(':').map(Number);
 
-  const startTimeMatch = timeRegex.exec(startTime);
-  const endTimeMatch = timeRegex.exec(endTime);
+  const totalMinutes1 = hours1 * 60 + minutes1;
+  const totalMinutes2 = hours2 * 60 + minutes2;
 
-  if (!startTimeMatch || !endTimeMatch) {
-    throw new Error('Invalid time format');
-  }
+  const adjustedTotalMinutes2 =
+    totalMinutes2 < totalMinutes1 ? totalMinutes2 + 24 * 60 : totalMinutes2;
 
-  const startHours = parseInt(startTimeMatch[1], 10);
-  const startMinutes = parseInt(startTimeMatch[2], 10);
-  const startPeriod = startTimeMatch[3];
+  const differenceInMinutes = Math.abs(adjustedTotalMinutes2 - totalMinutes1);
 
-  const endHours = parseInt(endTimeMatch[1], 10);
-  const endMinutes = parseInt(endTimeMatch[2], 10);
-  const endPeriod = endTimeMatch[3];
-
-  const adjustedStartHours = (startHours % 12) + (startPeriod === 'PM' ? 12 : 0);
-  const adjustedEndHours = (endHours % 12) + (endPeriod === 'PM' ? 12 : 0);
-
-  let hours = adjustedEndHours - adjustedStartHours;
-  let minutes = endMinutes - startMinutes;
-
-  if (hours < 0) {
-    hours += 24;
-  }
-
-  if (minutes < 0) {
-    minutes += 60;
-    hours -= 1;
-  }
+  let hours = Math.floor(differenceInMinutes / 60);
+  const minutes = differenceInMinutes % 60;
 
   if (startTime === endTime) {
     hours = 24;
   }
 
-  return {
-    hours,
-    minutes,
-  };
+  return { hours, minutes };
 }

--- a/src/utils/defineCustomTime.ts
+++ b/src/utils/defineCustomTime.ts
@@ -1,3 +1,8 @@
+// function to combine specified date and time in a single date
+//  @param date - Thu Dec 21 2023 00:00:00 GMT+0200
+//  @param timeString - '01:15'
+//  @return - Thu Dec 21 2023 01:15:00 GMT+0200
+
 export function setCustomTime(date: Date, timeString: string): Date {
   const newDate = new Date(date);
 

--- a/src/utils/defineCustomTime.ts
+++ b/src/utils/defineCustomTime.ts
@@ -1,16 +1,11 @@
 export function setCustomTime(date: Date, timeString: string): Date {
   const newDate = new Date(date);
 
-  const match = timeString.match(/^(\d{1,2}):(\d{2}) ([APMapm]{2})$/);
+  const match = timeString.match(/^(\d{1,2}):(\d{2})$/);
 
   if (match) {
-    let hours = parseInt(match[1], 10);
+    const hours = parseInt(match[1], 10);
     const minutes = parseInt(match[2], 10);
-    const period = match[3].toUpperCase();
-
-    if (period === 'PM' && hours < 12) {
-      hours += 12;
-    }
 
     newDate.setHours(hours, minutes, 0, 0);
   }

--- a/src/utils/extractTimeFromDate.ts
+++ b/src/utils/extractTimeFromDate.ts
@@ -1,3 +1,7 @@
+// function to extract time from date stored in ISO 8601 format
+//  @param date - 2023-12-20T23:15:00.000Z
+//  @return - '01:15"
+
 export function extractTimeFromDate(dateString: Date): string {
   const dateObject = new Date(dateString);
 

--- a/src/utils/extractTimeFromDate.ts
+++ b/src/utils/extractTimeFromDate.ts
@@ -1,0 +1,12 @@
+export function extractTimeFromDate(dateString: Date): string {
+  const dateObject = new Date(dateString);
+
+  dateObject.setUTCHours(dateObject.getUTCHours() + 2);
+
+  const hours = String(dateObject.getUTCHours()).padStart(2, '0');
+  const minutes = String(dateObject.getUTCMinutes()).padStart(2, '0');
+
+  const formattedTime = `${hours}:${minutes}`;
+
+  return formattedTime;
+}

--- a/src/utils/generateTime.ts
+++ b/src/utils/generateTime.ts
@@ -1,6 +1,8 @@
-// generate array of time periods with defined interval:
-// input: generateTimeWithInterval('08:00', '10:00', 15);
-// output: ['08:00', '08:15', '08:30', '08:45', '09:00', '09:15', '09:30', '09:45', '10:00']
+// function to generate an array of time periods with defined interval
+//  @param startTime - '08:00'
+//  @param endTime - '10:00'
+//  @param intervalMinutes - 15
+//  @return -  ['08:00', '08:15', '08:30', '08:45', '09:00', '09:15', '09:30', '09:45', '10:00']
 
 const DATE_CONSTANT = '1970-01-01T';
 

--- a/src/utils/generateTime.ts
+++ b/src/utils/generateTime.ts
@@ -1,29 +1,31 @@
 // generate array of time periods with defined interval:
-// input: generateTimeWithInterval('08:00 AM', '10:00 AM', 15);
-// output: ['08:00 AM', '08:15 AM', '08:30 AM', '08:45 AM', '09:00 AM', '09:15 AM', '09:30 AM', '09:45 AM', '10:00 AM']
+// input: generateTimeWithInterval('08:00', '10:00', 15);
+// output: ['08:00', '08:15', '08:30', '08:45', '09:00', '09:15', '09:30', '09:45', '10:00']
 
-export function generateTimeWithInterval(start: string, end: string, interval: number): string[] {
-  const adjustedStart =
-    (parseInt(start.slice(0, 2), 10) * 60 + parseInt(start.slice(3, 5), 10)) / interval;
-  const adjustedEnd =
-    (parseInt(end.slice(0, 2), 10) * 60 + parseInt(end.slice(3, 5), 10)) / interval + 1;
+const DATE_CONSTANT = '1970-01-01T';
 
-  const times = Array.from({ length: adjustedEnd - adjustedStart }, (_, i) => {
-    const totalMinutes = (i + adjustedStart) * interval;
-    let hour = Math.floor(totalMinutes / 60) % 24;
-    let minute = totalMinutes % 60;
+export function generateTimeWithInterval(
+  startTime: string,
+  endTime: string,
+  intervalMinutes: number
+): string[] {
+  const startDate = new Date(`${DATE_CONSTANT}${startTime}:00`);
+  let endDate = new Date(`${DATE_CONSTANT}${endTime}:00`);
 
-    if (hour === 24 && minute === 0) {
-      hour = 23;
-      minute = 45;
-    }
+  if (endDate < startDate) {
+    endDate = new Date(endDate.getTime() + 24 * 60 * 60 * 1000);
+  }
 
-    const formattedHour = `${hour === 0 ? '00' : hour}`.padStart(2, '0');
-    const formattedMinute = `${minute}`.padStart(2, '0');
-    const period = hour < 12 ? 'AM' : 'PM';
+  const timeArray = [];
+  const currentTime = startDate;
 
-    return `${formattedHour}:${formattedMinute} ${period}`;
-  });
+  while (currentTime <= endDate) {
+    const hours = currentTime.getHours().toString().padStart(2, '0');
+    const minutes = currentTime.getMinutes().toString().padStart(2, '0');
+    const formattedTime = `${hours}:${minutes}`;
+    timeArray.push(formattedTime);
+    currentTime.setMinutes(currentTime.getMinutes() + intervalMinutes);
+  }
 
-  return times;
+  return timeArray;
 }


### PR DESCRIPTION
## Describe your changes

- I changed profile availability logic so that when the user chooses start time then the end time's value should automatically be + 1 hour. also the end time can't be less than the start time. 
- in profile the logic was moved to custom hook
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/116946245/6d3bf255-0c85-4295-96be-9520dd8c84c0)
Also the user cannot choose identical time:
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/116946245/5175496e-8354-4f56-8748-bfa20d7a7196)
- the time handling logic was refactored and am/pm format was removed from selects and from logic.
- at the appointment page in type of an appointment startDate/endDate and startTime/endTime are taken from the appointment slice so that when the user go back to one step, he/she could see all the info entered at previous step

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.

