### PR TITLE
fix: updated common styles of Complete profile

### DIFF
--- a/src/components/complete-profile-fifth/CompleteProfileFifth.tsx
+++ b/src/components/complete-profile-fifth/CompleteProfileFifth.tsx
@@ -27,9 +27,10 @@ import ProfileBtn from 'src/components/reusable/profile-btn/ProfileBtn';
 
 interface IProps {
   onNext: () => void;
+  onBack: () => void;
 }
 
-function CompleteProfileFifth({ onNext }: IProps): JSX.Element {
+function CompleteProfileFifth({ onNext, onBack }: IProps): JSX.Element {
   const { translate } = useLocales();
   const dispatch = useAppDispatch();
   const completeProfileFifthSchema = useCompleteProfileFifthSchema();
@@ -112,7 +113,12 @@ function CompleteProfileFifth({ onNext }: IProps): JSX.Element {
             <ErrorMessage variant="caption">{errors.hourlyRate?.message}</ErrorMessage>
           )}
         </InputWrapper>
-        <ProfileBtn text={translate('btn_next')} disabled={!isDirty || !isValid} />
+        <ProfileBtn
+          nextText={translate('btn_next')}
+          backText={translate('profileQualification.back')}
+          disabled={!isDirty || !isValid}
+          onBack={onBack}
+        />
       </StyledForm>
     </Wrapper>
   );

--- a/src/components/complete-profile-fourth/CompleteProfileFourth.tsx
+++ b/src/components/complete-profile-fourth/CompleteProfileFourth.tsx
@@ -17,13 +17,12 @@ import {
   Wrapper,
 } from './styles';
 
-export default function CompleteProfileFourth({
-  onNext,
-  onBack,
-}: {
+interface IProps {
   onNext: () => void;
   onBack: () => void;
-}): JSX.Element {
+}
+
+export default function CompleteProfileFourth({ onNext, onBack }: IProps): JSX.Element {
   const { translate } = useLocales();
   const dispatch = useAppDispatch();
   const { days: availableDays } = useTypedSelector((state) => state.availableDays);

--- a/src/components/complete-profile-fourth/CompleteProfileFourth.tsx
+++ b/src/components/complete-profile-fourth/CompleteProfileFourth.tsx
@@ -17,7 +17,13 @@ import {
   Wrapper,
 } from './styles';
 
-export default function CompleteProfileFourth({ onNext }: { onNext: () => void }): JSX.Element {
+export default function CompleteProfileFourth({
+  onNext,
+  onBack,
+}: {
+  onNext: () => void;
+  onBack: () => void;
+}): JSX.Element {
   const { translate } = useLocales();
   const dispatch = useAppDispatch();
   const { days: availableDays } = useTypedSelector((state) => state.availableDays);
@@ -137,9 +143,11 @@ export default function CompleteProfileFourth({ onNext }: { onNext: () => void }
           <Alert severity="error">{translate('unexpected_error')}</Alert>
         </Snackbar>
         <ProfileBtn
-          text={translate('btn_next')}
+          nextText={translate('btn_next')}
+          backText={translate('profileQualification.back')}
           onClick={defineAvailableDays}
           disabled={!daySelected || !availableFrom || !availableTo}
+          onBack={onBack}
         />
       </Container>
     </Wrapper>

--- a/src/components/complete-profile-second/CompleteProfileSecond.tsx
+++ b/src/components/complete-profile-second/CompleteProfileSecond.tsx
@@ -14,9 +14,10 @@ import { Title } from 'src/components/complete-profile-second/styles';
 
 interface IProps {
   onNext: () => void;
+  onBack: () => void;
 }
 
-function CompleteProfileSecond({ onNext }: IProps): JSX.Element | null {
+function CompleteProfileSecond({ onNext, onBack }: IProps): JSX.Element | null {
   const [editingWorkPlaces, setEditingWorkPlaces] = useState<ProfileExperience | null>(null);
   const [isModalActive, setIsModalActive] = useState<boolean>(false);
   const workPlaces = useTypedSelector((state) => state.workExperience.workExperiences);
@@ -87,6 +88,7 @@ function CompleteProfileSecond({ onNext }: IProps): JSX.Element | null {
       ) : (
         <WorkList
           onNext={onNext}
+          onBack={onBack}
           onClose={onCloseModal}
           onOpen={onOpenModal}
           isModalActive={isModalActive}

--- a/src/components/complete-profile-second/work-form/WorkForm.tsx
+++ b/src/components/complete-profile-second/work-form/WorkForm.tsx
@@ -25,10 +25,14 @@ import {
   MAX_WORK_DATE,
 } from 'src/components/complete-profile-second/work-form/constants';
 import { useExperienceSelectOptions } from 'src/components/complete-profile-second/work-form/select-options';
-import { ErrorMessage, StyledForm } from 'src/components/complete-profile-second/work-form/styles';
+import {
+  ErrorMessage,
+  StyledForm,
+  StyledButton,
+  ButtonWrapper,
+} from 'src/components/complete-profile-second/work-form/styles';
 import { useProfileExperienceSchema } from 'src/components/complete-profile-second/work-form/validation';
 import { DATE_FORMAT, BACKEND_DATE_FORMAT } from 'src/constants';
-import ProfileBtn from 'src/components/reusable/profile-btn/ProfileBtn';
 import { useLocales } from 'src/locales';
 
 type Props = {
@@ -197,7 +201,11 @@ export default function WorkForm({ onClose, onSave, editingWorkPlaces }: Props):
           labelPlacement="end"
         />
       </Stack>
-      <ProfileBtn text={translate('profileQualification.save')} disabled={!isValid} />
+      <ButtonWrapper>
+        <StyledButton type="submit" disabled={!isValid} variant="contained">
+          {translate('profileQualification.save')}
+        </StyledButton>
+      </ButtonWrapper>
     </StyledForm>
   );
 }

--- a/src/components/complete-profile-second/work-form/styles.ts
+++ b/src/components/complete-profile-second/work-form/styles.ts
@@ -28,9 +28,14 @@ export const ErrorMessage = styled(Typography)`
   font-weight: ${typography.fontWeightMedium};
 `;
 
+export const ButtonWrapper = styled('div')`
+  border-top: 1px solid var(--divider, rgba(0, 0, 0, 0.12));
+  padding: 16px 0 0;
+  margin-top: auto;
+`;
+
 export const StyledButton = styled(Button)`
   border-radius: 4px;
   width: 100%;
   height: 40px;
-  margin-top: auto;
 `;

--- a/src/components/complete-profile-second/work-form/styles.ts
+++ b/src/components/complete-profile-second/work-form/styles.ts
@@ -29,7 +29,7 @@ export const ErrorMessage = styled(Typography)`
 `;
 
 export const ButtonWrapper = styled('div')`
-  border-top: 1px solid var(--divider, rgba(0, 0, 0, 0.12));
+  border-top: 1px solid ${SECONDARY.light_gray};
   padding: 16px 0 0;
   margin-top: auto;
 `;

--- a/src/components/complete-profile-second/work-list/WorkList.tsx
+++ b/src/components/complete-profile-second/work-list/WorkList.tsx
@@ -3,9 +3,7 @@ import { Box, Divider, IconButton, List, ListItem } from '@mui/material';
 import { Create, Delete } from '@mui/icons-material';
 import { parse } from 'date-fns';
 
-import {
-  useCreateWorkExperienceMutation,
-} from 'src/redux/api/profileCompleteApi';
+import { useCreateWorkExperienceMutation } from 'src/redux/api/profileCompleteApi';
 import { saveWorkExperiences } from 'src/redux/slices/workEperienceSlice';
 import { useAppDispatch, useTypedSelector } from 'src/redux/store';
 import WorkForm from 'src/components/complete-profile-second/work-form/WorkForm';
@@ -25,6 +23,7 @@ type Props = {
   onClose: () => void;
   onOpen: () => void;
   onNext: () => void;
+  onBack: () => void;
   onEdit: (workPlace: ProfileExperience) => void;
   onSave: (updatedWorkPlace: ProfileExperience) => void;
   isModalActive: boolean;
@@ -36,6 +35,7 @@ export default function WorkList({
   onClose,
   onOpen,
   onNext,
+  onBack,
   onEdit,
   onSave,
   editingWorkPlaces,
@@ -124,10 +124,14 @@ export default function WorkList({
         <StyledButton variant="outlined" onClick={onOpen}>
           {translate('completeProfileSecond.addWorkPlace')}
         </StyledButton>
-
-        <StyledButton variant="contained" onClick={onNext}>
-          {translate('completeProfileSecond.next')}
-        </StyledButton>
+        <Box display="flex" gap={1}>
+          <StyledButton variant="outlined" onClick={onBack}>
+            {translate('profileQualification.back')}
+          </StyledButton>
+          <StyledButton variant="contained" onClick={onNext}>
+            {translate('profileQualification.next')}
+          </StyledButton>
+        </Box>
       </ButtonWrapper>
 
       <Modal

--- a/src/components/complete-profile-third/CompleteProfileThird.tsx
+++ b/src/components/complete-profile-third/CompleteProfileThird.tsx
@@ -10,7 +10,7 @@ import { useLocales } from 'src/locales';
 import { saveServices } from 'src/redux/slices/servicesSlice';
 import { useAppDispatch, useTypedSelector } from 'src/redux/store';
 
-function CompleteProfileThird({ onNext }: IProps): JSX.Element {
+function CompleteProfileThird({ onNext, onBack }: IProps): JSX.Element {
   const { translate } = useLocales();
   const dispatch = useAppDispatch();
   const { onUpdateServices } = useCompleteProfileThird(onNext);
@@ -136,7 +136,12 @@ function CompleteProfileThird({ onNext }: IProps): JSX.Element {
             />
           }
         />
-        <ProfileBtn text={translate('btn_next')} disabled={!isDirty} />
+        <ProfileBtn
+          nextText={translate('btn_next')}
+          backText={translate('profileQualification.back')}
+          disabled={!isDirty}
+          onBack={onBack}
+        />
       </StyledForm>
     </Wrapper>
   );

--- a/src/components/complete-profile-third/CompleteProfileThird.tsx
+++ b/src/components/complete-profile-third/CompleteProfileThird.tsx
@@ -20,7 +20,7 @@ function CompleteProfileThird({ onNext, onBack }: IProps): JSX.Element {
   const {
     control,
     handleSubmit,
-    formState: { isDirty },
+    formState: { isDirty, isValid },
   } = useForm<CompleteProfileThirdValues>({
     mode: 'onBlur',
     defaultValues: initialServicesValues,
@@ -139,7 +139,7 @@ function CompleteProfileThird({ onNext, onBack }: IProps): JSX.Element {
         <ProfileBtn
           nextText={translate('btn_next')}
           backText={translate('profileQualification.back')}
-          disabled={!isDirty}
+          disabled={!isDirty || !isValid}
           onBack={onBack}
         />
       </StyledForm>

--- a/src/components/complete-profile-third/types.ts
+++ b/src/components/complete-profile-third/types.ts
@@ -9,6 +9,7 @@ export type CompleteProfileThirdValues = {
 
 export interface IProps {
   onNext: () => void;
+  onBack: () => void;
 }
 
 export type ReturnType = {

--- a/src/components/profile/bio/Bio.tsx
+++ b/src/components/profile/bio/Bio.tsx
@@ -15,7 +15,6 @@ import { useBioFormSchema } from 'src/components/profile/bio/validation';
 import {
   ErrorMessage,
   MediaWrapper,
-  StyledSubmitButton,
   StyledForm,
   StyledIconButton,
   StyledVideo,
@@ -30,8 +29,9 @@ import {
   MOV_FORMAT,
   MP4_FORMAT,
 } from 'src/components/profile/bio/constants';
+import ProfileBtn from 'src/components/reusable/profile-btn/ProfileBtn';
 
-export function Bio(): JSX.Element {
+export function Bio({ onBack }: { onBack: () => void }): JSX.Element {
   const [videoPreviewURL, setVideoPreviewURL] = useState<string>('');
   const [uploadVideoMutation] = useUploadFileMutation();
   const [updateDescription] = useUpdateProfileMutation();
@@ -153,9 +153,12 @@ export function Bio(): JSX.Element {
         )}
       </StyledFormControl>
 
-      <StyledSubmitButton type="submit" disabled={!isValid} variant="contained" color="primary">
-        {translate('profileBio.submit')}
-      </StyledSubmitButton>
+      <ProfileBtn
+        nextText={translate('profileBio.submit')}
+        backText={translate('profileQualification.back')}
+        disabled={!isValid}
+        onBack={onBack}
+      />
     </StyledForm>
   );
 }

--- a/src/components/profile/bio/Bio.tsx
+++ b/src/components/profile/bio/Bio.tsx
@@ -31,7 +31,11 @@ import {
 } from 'src/components/profile/bio/constants';
 import ProfileBtn from 'src/components/reusable/profile-btn/ProfileBtn';
 
-export function Bio({ onBack }: { onBack: () => void }): JSX.Element {
+interface IProps {
+  onBack: () => void;
+}
+
+export function Bio({ onBack }: IProps): JSX.Element {
   const [videoPreviewURL, setVideoPreviewURL] = useState<string>('');
   const [uploadVideoMutation] = useUploadFileMutation();
   const [updateDescription] = useUpdateProfileMutation();

--- a/src/components/profile/profile-qualification/certificate-form/CertificateForm.tsx
+++ b/src/components/profile/profile-qualification/certificate-form/CertificateForm.tsx
@@ -20,10 +20,11 @@ import {
 import {
   ErrorMessage,
   StyledForm,
+  StyledButton,
+  ButtonWrapper,
 } from 'src/components/profile/profile-qualification/certificate-form/styles';
 import { useProfileQualificationSchema } from 'src/components/profile/profile-qualification/certificate-form/validation';
 import { ProfileQuality } from 'src/components/profile/profile-qualification/types';
-import ProfileBtn from 'src/components/reusable/profile-btn/ProfileBtn';
 import { useLocales } from 'src/locales';
 import { BACKEND_DATE_FORMAT, DATE_FORMAT } from 'src/constants';
 import { Certificate, profileApi } from 'src/redux/api/profileCompleteApi';
@@ -203,7 +204,11 @@ export default function CertificateForm({
           labelPlacement="start"
         />
       </Stack>
-      <ProfileBtn text={translate('profileQualification.save')} disabled={!isValid} />
+      <ButtonWrapper>
+        <StyledButton type="submit" disabled={!isValid} variant="contained">
+          {translate('profileQualification.save')}
+        </StyledButton>
+      </ButtonWrapper>
     </StyledForm>
   );
 }

--- a/src/components/profile/profile-qualification/certificate-form/styles.ts
+++ b/src/components/profile/profile-qualification/certificate-form/styles.ts
@@ -28,9 +28,14 @@ export const ErrorMessage = styled(Typography)`
   font-weight: ${typography.fontWeightMedium};
 `;
 
+export const ButtonWrapper = styled('div')`
+  border-top: 1px solid var(--divider, rgba(0, 0, 0, 0.12));
+  padding: 16px 0 0;
+  margin-top: auto;
+`;
+
 export const StyledButton = styled(Button)`
   border-radius: 4px;
   width: 100%;
   height: 40px;
-  margin-top: auto;
 `;

--- a/src/components/profile/profile-qualification/certificate-form/styles.ts
+++ b/src/components/profile/profile-qualification/certificate-form/styles.ts
@@ -29,7 +29,7 @@ export const ErrorMessage = styled(Typography)`
 `;
 
 export const ButtonWrapper = styled('div')`
-  border-top: 1px solid var(--divider, rgba(0, 0, 0, 0.12));
+  border-top: 1px solid ${SECONDARY.light_gray};
   padding: 16px 0 0;
   margin-top: auto;
 `;

--- a/src/components/reusable/profile-btn/ProfileBtn.tsx
+++ b/src/components/reusable/profile-btn/ProfileBtn.tsx
@@ -1,18 +1,32 @@
 import React from 'react';
+import { Box } from '@mui/material';
 import { ButtonWrapper, NextButton } from './styles';
 
 type Props = {
-  text: string;
+  nextText: string;
+  backText: string;
   disabled: boolean;
   onClick?: () => void;
+  onBack?: () => void;
 };
 
-export default function ProfileBtn({ text, disabled, onClick }: Props): JSX.Element {
+export default function ProfileBtn({
+  nextText,
+  backText,
+  disabled,
+  onClick,
+  onBack,
+}: Props): JSX.Element {
   return (
     <ButtonWrapper>
-      <NextButton onClick={onClick} variant="contained" type="submit" disabled={disabled}>
-        {text}
-      </NextButton>
+      <Box display="flex" gap={1}>
+        <NextButton variant="outlined" onClick={onBack}>
+          {backText}
+        </NextButton>
+        <NextButton onClick={onClick} variant="contained" type="submit" disabled={disabled}>
+          {nextText}
+        </NextButton>
+      </Box>
     </ButtonWrapper>
   );
 }

--- a/src/components/reusable/profile-btn/styles.ts
+++ b/src/components/reusable/profile-btn/styles.ts
@@ -1,7 +1,8 @@
 import { Button, styled } from '@mui/material';
+import { SECONDARY } from 'src/theme/colors';
 
 export const ButtonWrapper = styled('div')`
-  border-top: 1px solid var(--divider, rgba(0, 0, 0, 0.12));
+  border-top: 1px solid ${SECONDARY.light_gray};
   padding: 16px 0 0;
   margin-top: auto;
 `;

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -202,6 +202,7 @@ const en = {
     save: 'Save',
     return: 'Return',
     delete: 'Delete',
+    back: 'Back',
 
     addCertificate: 'Add Another Certificate',
 

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -36,6 +36,12 @@ function Profile(): JSX.Element | null {
     setActiveStepIndex(activeStepIndex + SECOND_STEP_INDEX);
   };
 
+  const handleBack = (): void => {
+    if (activeStepIndex > FIRST_STEP_INDEX) {
+      setActiveStepIndex(activeStepIndex - SECOND_STEP_INDEX);
+    }
+  };
+
   const STEPS: Step[] = [
     {
       label: translate('profile.qualification'),
@@ -43,33 +49,27 @@ function Profile(): JSX.Element | null {
     },
     {
       label: translate('profile.workExperience'),
-      component: <CompleteProfileSecond onNext={handleNext} />,
+      component: <CompleteProfileSecond onNext={handleNext} onBack={handleBack} />,
     },
     {
       label: translate('profile.services'),
-      component: <CompleteProfileThird onNext={handleNext} />,
+      component: <CompleteProfileThird onNext={handleNext} onBack={handleBack} />,
     },
     {
       label: translate('profile.availability'),
-      component: <CompleteProfileFourth onNext={handleNext} />,
+      component: <CompleteProfileFourth onNext={handleNext} onBack={handleBack} />,
     },
     {
       label: translate('profile.rates'),
-      component: <CompleteProfileFifth onNext={handleNext} />,
+      component: <CompleteProfileFifth onNext={handleNext} onBack={handleBack} />,
     },
     {
       label: translate('profile.bio'),
-      component: <Bio />,
+      component: <Bio onBack={handleBack} />,
     },
   ];
 
   const ActiveStepComponent = STEPS[activeStepIndex].component;
-
-  const handleBack = (): void => {
-    if (activeStepIndex > FIRST_STEP_INDEX) {
-      setActiveStepIndex(activeStepIndex - SECOND_STEP_INDEX);
-    }
-  };
 
   const handleStep = (stepIndex: number) => () => {
     if (stepIndex === FIRST_STEP_INDEX || completed[stepIndex - SECOND_STEP_INDEX]) {
@@ -82,7 +82,7 @@ function Profile(): JSX.Element | null {
       <Head>
         <title>{translate('profile.pageTitle')}</title>
       </Head>
-      <FlowHeader text={translate('profile.headerTitle')} iconType="back" callback={handleBack} />
+      <FlowHeader text={translate('profile.headerTitle')} />
       <HorizontalStepper
         activeStep={activeStepIndex}
         completed={completed}


### PR DESCRIPTION
## Describe your changes
add Back Button to Profile button component;
updated profile page;
add onBack props to 2-6 Complete profile components; 
removed icon from Complete profile header

<img width="753" alt="Снимок экрана 2023-12-06 165308" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/c111be95-a938-44d4-8dc0-a434d4dbd87f">
<img width="751" alt="Снимок экрана 2023-12-06 165351" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/3cd27a36-4506-4ca7-8fad-129358b8b320">

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-147)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
