### PR TITLE
Feat: FE Appointments page

### DIFF
--- a/src/components/appointments/Appointments.tsx
+++ b/src/components/appointments/Appointments.tsx
@@ -4,10 +4,10 @@ import { useLocales } from 'src/locales';
 import { ROUTES } from 'src/routes';
 
 import AppointmentsList from './appointments-list/AppointmentsList';
-import { PropsType } from './types';
+import { AppointmentsProps } from './types';
 import { Background, Container, HeadContainer, Title, StyledButton } from './styles';
 
-export default function Appointments({ appointments }: PropsType): JSX.Element {
+export default function Appointments({ appointments }: AppointmentsProps): JSX.Element {
   const { translate } = useLocales();
   const router = useRouter();
 

--- a/src/components/appointments/Appointments.tsx
+++ b/src/components/appointments/Appointments.tsx
@@ -1,0 +1,31 @@
+import { useRouter } from 'next/router';
+
+import { useLocales } from 'src/locales';
+import { ROUTES } from 'src/routes';
+
+import AppointmentsList from './appointments-list/AppointmentsList';
+import { PropsType } from './types';
+import { Background, Container, HeadContainer, Title, StyledButton } from './styles';
+
+export default function Appointments({ appointments }: PropsType): JSX.Element {
+  const { translate } = useLocales();
+  const router = useRouter();
+
+  return (
+    <Background>
+      <Container>
+        <HeadContainer>
+          <Title>{translate('appointments_page.page_title')}</Title>
+          <StyledButton
+            variant="contained"
+            type="button"
+            onClick={(): Promise<boolean> => router.push(ROUTES.create_appointment)}
+          >
+            {translate('appointments_page.create_button')}
+          </StyledButton>
+        </HeadContainer>
+        <AppointmentsList appointments={appointments} />
+      </Container>
+    </Background>
+  );
+}

--- a/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
+++ b/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
@@ -12,10 +12,8 @@ import { SMALL_CAREGIVER_AVATAR_SIZE } from 'src/components/appointments/constan
 import {
   getMockCaregiverAvatar,
   getFormattedDate,
-  mockedTasks,
-  mockedCaregiver,
+  mockedAppointment,
 } from 'src/components/appointments/helpers';
-import { AppointmentType } from 'src/components/appointments/types';
 
 import ArrowBackFilled from 'src/assets/icons/ArrowBackFilled';
 import RightAction from 'src/assets/icons/RightAction';
@@ -40,20 +38,17 @@ interface AppointmentsDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   setIsDrawerOpen: Dispatch<SetStateAction<boolean>>;
-  selectedAppointment: AppointmentType;
+  selectedAppointmentId: string;
 }
 
 export default function AppointmentDrawer({
   isOpen,
   onClose,
   setIsDrawerOpen,
-  selectedAppointment,
+  selectedAppointmentId,
 }: AppointmentsDrawerProps): JSX.Element {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const formattedStartDate = useMemo(
-    () => getFormattedDate(selectedAppointment.startDate),
-    [selectedAppointment.startDate]
-  );
+  const formattedStartDate = useMemo(() => getFormattedDate(mockedAppointment.startDate), []);
 
   const { translate } = useLocales();
 
@@ -80,7 +75,7 @@ export default function AppointmentDrawer({
     [APPOINTMENT_STATUS.Active]: (
       <DoubleButtonBox>
         <StyledButton type="button" variant="contained">
-          {translate('appointments_page.signIn_button')}
+          {translate('appointments_page.contract_button')}
         </StyledButton>
         <CancelBtn type="button" variant="outlined">
           {translate('appointments_page.cancel_appointment_button')}
@@ -105,18 +100,19 @@ export default function AppointmentDrawer({
         </DrawerHeader>
         <DrawerBody>
           <Block>
-            <AppointmentName>{selectedAppointment.name}</AppointmentName>
-            <AppointmentStatus status={selectedAppointment.status} />
+            <AppointmentName>{mockedAppointment.name}</AppointmentName>
+            <AppointmentStatus status={mockedAppointment.status} />
           </Block>
           <Block>
             <SubTitle>{translate('appointments_page.drawer.caregiver')}</SubTitle>
             <CaregiverBlock>
               <DrawerAvatar
                 src={getMockCaregiverAvatar(SMALL_CAREGIVER_AVATAR_SIZE)}
-                alt={`${mockedCaregiver.firstName} ${mockedCaregiver.lastName}`}
+                alt={`${mockedAppointment.caregiverInfo.user.firstName} ${mockedAppointment.caregiverInfo.user.lastName}`}
               />
               <CaregiverName>
-                {mockedCaregiver.firstName} {mockedCaregiver.lastName}
+                {mockedAppointment.caregiverInfo.user.firstName}
+                {mockedAppointment.caregiverInfo.user.lastName}
               </CaregiverName>
               <StyledIconButton edge="end" aria-label="open-drawer">
                 <RightAction />
@@ -130,21 +126,21 @@ export default function AppointmentDrawer({
           <Block>
             <SubTitle>{translate('appointments_page.drawer.tasks')}</SubTitle>
             <TaskList>
-              {mockedTasks.map((task) => (
-                <Task key={task.id}>{task.name}</Task>
+              {mockedAppointment.seekerTasks.map((task) => (
+                <Task key={task.appointmentId}>{task.name}</Task>
               ))}
             </TaskList>
           </Block>
           <Block>
             <SubTitle>{translate('appointments_page.drawer.details')}</SubTitle>
-            {selectedAppointment.details ? (
-              <DateText>{selectedAppointment.details}</DateText>
+            {mockedAppointment.details ? (
+              <DateText>{mockedAppointment.details}</DateText>
             ) : (
               <DateText>{translate('appointments_page.drawer.details_empty')}</DateText>
             )}
           </Block>
         </DrawerBody>
-        <DrawerFooter>{DRAWER_FOOTERS[selectedAppointment.status]}</DrawerFooter>
+        <DrawerFooter>{DRAWER_FOOTERS[mockedAppointment.status]}</DrawerFooter>
       </Drawer>
       <Modal
         onClose={handleModalClose}

--- a/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
+++ b/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState, Dispatch, SetStateAction } from 'react';
+import { IconButton } from '@mui/material';
+
+import { useLocales } from 'src/locales';
+import { APPOINTMENT_STATUS } from 'src/constants';
+import Drawer from 'src/components/reusable/drawer/Drawer';
+import { DrawerFooter, DrawerHeader, DrawerTitle } from 'src/components/reusable/drawer/styles';
+import Modal from 'src/components/reusable/modal/Modal';
+import CancelModal from 'src/components/appointments/cancel-modal/CancelModal';
+import AppointmentStatus from 'src/components/appointments/appointment-status/AppointmentStatus';
+import { SMALL_CAREGIVER_AVATAR_SIZE } from 'src/components/appointments/constants';
+import {
+  getMockCaregiverAvatar,
+  getFormattedDate,
+  mockedTasks,
+  mockedCaregiver,
+} from 'src/components/appointments/helpers';
+import { AppointmentType } from 'src/components/appointments/types';
+
+import ArrowBackFilled from 'src/assets/icons/ArrowBackFilled';
+import RightAction from 'src/assets/icons/RightAction';
+import {
+  DrawerBody,
+  Block,
+  AppointmentName,
+  SubTitle,
+  CaregiverName,
+  DrawerAvatar,
+  CaregiverBlock,
+  StyledIconButton,
+  DateText,
+  TaskList,
+  Task,
+  CancelBtn,
+  StyledButton,
+  DoubleButtonBox,
+} from './styles';
+
+interface AppointmentsDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  setIsDrawerOpen: Dispatch<SetStateAction<boolean>>;
+  selectedAppointment: AppointmentType;
+}
+
+export default function AppointmentDrawer({
+  isOpen,
+  onClose,
+  setIsDrawerOpen,
+  selectedAppointment,
+}: AppointmentsDrawerProps): JSX.Element {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const formattedStartDate = useMemo(
+    () => getFormattedDate(selectedAppointment.startDate),
+    [selectedAppointment.startDate]
+  );
+
+  const { translate } = useLocales();
+
+  const handleModalOpen = (): void => {
+    setIsModalOpen(true);
+    setIsDrawerOpen(false);
+  };
+  const handleModalClose = (): void => {
+    setIsModalOpen(false);
+    setIsDrawerOpen(true);
+  };
+
+  return (
+    <>
+      <Drawer open={isOpen} onClose={onClose}>
+        <DrawerHeader>
+          <IconButton size="small" onClick={onClose}>
+            <ArrowBackFilled />
+          </IconButton>
+          <DrawerTitle>{translate('appointments_page.page_title')}</DrawerTitle>
+        </DrawerHeader>
+        <DrawerBody>
+          <Block>
+            <AppointmentName>{selectedAppointment.name}</AppointmentName>
+            <AppointmentStatus status={selectedAppointment.status} />
+          </Block>
+          <Block>
+            <SubTitle>{translate('appointments_page.drawer.caregiver')}</SubTitle>
+            <CaregiverBlock>
+              <DrawerAvatar
+                src={getMockCaregiverAvatar(SMALL_CAREGIVER_AVATAR_SIZE)}
+                alt={`${mockedCaregiver.firstName} ${mockedCaregiver.lastName}`}
+              />
+              <CaregiverName>
+                {mockedCaregiver.firstName} {mockedCaregiver.lastName}
+              </CaregiverName>
+              <StyledIconButton edge="end" aria-label="open-drawer">
+                <RightAction />
+              </StyledIconButton>
+            </CaregiverBlock>
+          </Block>
+          <Block>
+            <SubTitle>{translate('appointments_page.drawer.date')}</SubTitle>
+            <DateText>{formattedStartDate}</DateText>
+          </Block>
+          <Block>
+            <SubTitle>{translate('appointments_page.drawer.tasks')}</SubTitle>
+            <TaskList>
+              {mockedTasks.map((task) => (
+                <Task key={task.id}>{task.name}</Task>
+              ))}
+            </TaskList>
+          </Block>
+          <Block>
+            <SubTitle>{translate('appointments_page.drawer.details')}</SubTitle>
+            {selectedAppointment.details ? (
+              <DateText>{selectedAppointment.details}</DateText>
+            ) : (
+              <DateText>{translate('appointments_page.drawer.details_empty')}</DateText>
+            )}
+          </Block>
+        </DrawerBody>
+        {selectedAppointment.status === APPOINTMENT_STATUS.Pending && (
+          <DrawerFooter>
+            <CancelBtn type="button" variant="outlined" onClick={handleModalOpen}>
+              {translate('appointments_page.cancel_button')}
+            </CancelBtn>
+          </DrawerFooter>
+        )}
+        {selectedAppointment.status === APPOINTMENT_STATUS.Accepted && (
+          <DrawerFooter>
+            <StyledButton type="button" variant="contained">
+              {translate('appointments_page.virtual_button')}
+            </StyledButton>
+          </DrawerFooter>
+        )}
+        {selectedAppointment.status === APPOINTMENT_STATUS.Virtual && (
+          <DrawerFooter>
+            <StyledButton type="button" variant="contained">
+              {translate('appointments_page.virtual_button')}
+            </StyledButton>
+          </DrawerFooter>
+        )}
+        {selectedAppointment.status === APPOINTMENT_STATUS.Active && (
+          <DrawerFooter>
+            <DoubleButtonBox>
+              <StyledButton type="button" variant="contained">
+                {translate('appointments_page.signIn_button')}
+              </StyledButton>
+              <CancelBtn type="button" variant="outlined">
+                {translate('appointments_page.cancel_appointment_button')}
+              </CancelBtn>
+            </DoubleButtonBox>
+          </DrawerFooter>
+        )}
+      </Drawer>
+      <Modal
+        onClose={handleModalClose}
+        title={translate('appointments_page.modal_title')}
+        isActive={isModalOpen}
+        children={<CancelModal onClose={handleModalClose} />}
+      />
+    </>
+  );
+}

--- a/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
+++ b/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
@@ -66,6 +66,34 @@ export default function AppointmentDrawer({
     setIsDrawerOpen(true);
   };
 
+  const DRAWER_FOOTERS = {
+    [APPOINTMENT_STATUS.Pending]: (
+      <CancelBtn type="button" variant="outlined" onClick={handleModalOpen}>
+        {translate('appointments_page.cancel_button')}
+      </CancelBtn>
+    ),
+    [APPOINTMENT_STATUS.Accepted]: (
+      <StyledButton type="button" variant="contained">
+        {translate('appointments_page.virtual_button')}
+      </StyledButton>
+    ),
+    [APPOINTMENT_STATUS.Active]: (
+      <DoubleButtonBox>
+        <StyledButton type="button" variant="contained">
+          {translate('appointments_page.signIn_button')}
+        </StyledButton>
+        <CancelBtn type="button" variant="outlined">
+          {translate('appointments_page.cancel_appointment_button')}
+        </CancelBtn>
+      </DoubleButtonBox>
+    ),
+    [APPOINTMENT_STATUS.Virtual]: (
+      <StyledButton type="button" variant="contained">
+        {translate('appointments_page.virtual_button')}
+      </StyledButton>
+    ),
+  };
+
   return (
     <>
       <Drawer open={isOpen} onClose={onClose}>
@@ -116,39 +144,7 @@ export default function AppointmentDrawer({
             )}
           </Block>
         </DrawerBody>
-        {selectedAppointment.status === APPOINTMENT_STATUS.Pending && (
-          <DrawerFooter>
-            <CancelBtn type="button" variant="outlined" onClick={handleModalOpen}>
-              {translate('appointments_page.cancel_button')}
-            </CancelBtn>
-          </DrawerFooter>
-        )}
-        {selectedAppointment.status === APPOINTMENT_STATUS.Accepted && (
-          <DrawerFooter>
-            <StyledButton type="button" variant="contained">
-              {translate('appointments_page.virtual_button')}
-            </StyledButton>
-          </DrawerFooter>
-        )}
-        {selectedAppointment.status === APPOINTMENT_STATUS.Virtual && (
-          <DrawerFooter>
-            <StyledButton type="button" variant="contained">
-              {translate('appointments_page.virtual_button')}
-            </StyledButton>
-          </DrawerFooter>
-        )}
-        {selectedAppointment.status === APPOINTMENT_STATUS.Active && (
-          <DrawerFooter>
-            <DoubleButtonBox>
-              <StyledButton type="button" variant="contained">
-                {translate('appointments_page.signIn_button')}
-              </StyledButton>
-              <CancelBtn type="button" variant="outlined">
-                {translate('appointments_page.cancel_appointment_button')}
-              </CancelBtn>
-            </DoubleButtonBox>
-          </DrawerFooter>
-        )}
+        <DrawerFooter>{DRAWER_FOOTERS[selectedAppointment.status]}</DrawerFooter>
       </Drawer>
       <Modal
         onClose={handleModalClose}

--- a/src/components/appointments/appointment-drawer/styles.ts
+++ b/src/components/appointments/appointment-drawer/styles.ts
@@ -1,0 +1,109 @@
+import { Avatar, Button, IconButton, styled } from '@mui/material';
+import { SECONDARY, PRIMARY, TEXT_COLOR } from 'src/theme/colors';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+import typography from 'src/theme/typography';
+
+export const DrawerBody = styled('div')`
+  display: flex;
+  gap: 16px;
+  flex-direction: column;
+  overflow-y: auto;
+  height: 100%;
+  background-color: ${SECONDARY.drawer_background};
+  width: 360px;
+  padding: 16px 0;
+`;
+
+export const Block = styled('div')`
+  border-top: 1px solid ${SECONDARY.light_gray};
+  border-bottom: 1px solid ${SECONDARY.light_gray};
+  background: ${PRIMARY.white};
+  padding: 16px;
+`;
+
+export const AppointmentName = styled('h3')`
+  font-size: ${TYPOGRAPHY.sm}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.6;
+  letter-spacing: 0.15px;
+  margin-bottom: 8px;
+`;
+
+export const SubTitle = styled('p')`
+  color: ${SECONDARY.gray_semi_transparent};
+  font-size: ${TYPOGRAPHY.xs}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.43;
+  letter-spacing: 0.17px;
+  margin-bottom: 8px;
+`;
+
+export const CaregiverBlock = styled('div')`
+  display: flex;
+  gap: 16px;
+  align-items: center;
+`;
+
+export const CaregiverName = styled('p')`
+  color: ${PRIMARY.black};
+  font-size: ${TYPOGRAPHY.sm}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.2;
+  letter-spacing: 0.15px;
+`;
+
+export const DrawerAvatar = styled(Avatar)`
+  width: 48px;
+  height: 48px;
+`;
+
+export const StyledIconButton = styled(IconButton)`
+  margin-left: auto;
+`;
+
+export const DateText = styled('p')`
+  color: ${PRIMARY.black};
+  font-size: ${TYPOGRAPHY.base}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+`;
+
+export const TaskList = styled('ul')`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Task = styled('li')`
+  color: ${PRIMARY.black};
+  font-size: ${TYPOGRAPHY.sm}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.6;
+  letter-spacing: 0.15px;
+  padding: 4px 0;
+  border-bottom: 1px solid ${SECONDARY.light_gray};
+`;
+
+export const CancelBtn = styled(Button)`
+  border-radius: 4px;
+  width: 100%;
+  color: ${TEXT_COLOR.error};
+  border-color: ${TEXT_COLOR.error};
+
+  &:hover {
+    background-color: ${SECONDARY.error_hover};
+    border: 1px solid ${TEXT_COLOR.error};
+  }
+`;
+
+export const StyledButton = styled(Button)`
+  border-radius: 4px;
+  width: 100%;
+`;
+
+export const DoubleButtonBox = styled('div')`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 16px;
+`;

--- a/src/components/appointments/appointment-status/AppointmentStatus.tsx
+++ b/src/components/appointments/appointment-status/AppointmentStatus.tsx
@@ -1,0 +1,36 @@
+import { APPOINTMENT_STATUS } from 'src/constants';
+import { useLocales } from 'src/locales';
+import { PendingStatus, ActiveStatus, RejectedStatus } from './styles';
+
+interface IProps {
+  status: string;
+}
+
+export default function AppointmentStatus({ status }: IProps): JSX.Element {
+  const { translate } = useLocales();
+  return (
+    <>
+      {status === APPOINTMENT_STATUS.Pending && (
+        <PendingStatus>{translate('appointments_page.status.pending')}</PendingStatus>
+      )}
+      {status === APPOINTMENT_STATUS.Accepted && (
+        <ActiveStatus>{translate('appointments_page.status.accepted')}</ActiveStatus>
+      )}
+      {status === APPOINTMENT_STATUS.Active && (
+        <ActiveStatus>{translate('appointments_page.status.active')}</ActiveStatus>
+      )}
+      {status === APPOINTMENT_STATUS.Completed && (
+        <ActiveStatus>{translate('appointments_page.status.completed')}</ActiveStatus>
+      )}
+      {status === APPOINTMENT_STATUS.Ongoing && (
+        <ActiveStatus>{translate('appointments_page.status.ongoing')}</ActiveStatus>
+      )}
+      {status === APPOINTMENT_STATUS.Virtual && (
+        <ActiveStatus>{translate('appointments_page.status.virtual')}</ActiveStatus>
+      )}
+      {status === APPOINTMENT_STATUS.Rejected && (
+        <RejectedStatus>{translate('appointments_page.status.rejected')}</RejectedStatus>
+      )}
+    </>
+  );
+}

--- a/src/components/appointments/appointment-status/AppointmentStatus.tsx
+++ b/src/components/appointments/appointment-status/AppointmentStatus.tsx
@@ -1,6 +1,6 @@
 import { APPOINTMENT_STATUS } from 'src/constants';
 import { useLocales } from 'src/locales';
-import { PendingStatus, ActiveStatus, RejectedStatus } from './styles';
+import { StatusWrapper } from './styles';
 
 interface IProps {
   status: string;
@@ -8,29 +8,16 @@ interface IProps {
 
 export default function AppointmentStatus({ status }: IProps): JSX.Element {
   const { translate } = useLocales();
-  return (
-    <>
-      {status === APPOINTMENT_STATUS.Pending && (
-        <PendingStatus>{translate('appointments_page.status.pending')}</PendingStatus>
-      )}
-      {status === APPOINTMENT_STATUS.Accepted && (
-        <ActiveStatus>{translate('appointments_page.status.accepted')}</ActiveStatus>
-      )}
-      {status === APPOINTMENT_STATUS.Active && (
-        <ActiveStatus>{translate('appointments_page.status.active')}</ActiveStatus>
-      )}
-      {status === APPOINTMENT_STATUS.Completed && (
-        <ActiveStatus>{translate('appointments_page.status.completed')}</ActiveStatus>
-      )}
-      {status === APPOINTMENT_STATUS.Ongoing && (
-        <ActiveStatus>{translate('appointments_page.status.ongoing')}</ActiveStatus>
-      )}
-      {status === APPOINTMENT_STATUS.Virtual && (
-        <ActiveStatus>{translate('appointments_page.status.virtual')}</ActiveStatus>
-      )}
-      {status === APPOINTMENT_STATUS.Rejected && (
-        <RejectedStatus>{translate('appointments_page.status.rejected')}</RejectedStatus>
-      )}
-    </>
-  );
+
+  const STATUS_TEXTS = {
+    [APPOINTMENT_STATUS.Pending]: translate('appointments_page.status.pending'),
+    [APPOINTMENT_STATUS.Accepted]: translate(`appointments_page.status.accepted`),
+    [APPOINTMENT_STATUS.Active]: translate('appointments_page.status.active'),
+    [APPOINTMENT_STATUS.Completed]: translate('appointments_page.status.completed'),
+    [APPOINTMENT_STATUS.Ongoing]: translate('appointments_page.status.ongoing'),
+    [APPOINTMENT_STATUS.Virtual]: translate('appointments_page.status.virtual'),
+    [APPOINTMENT_STATUS.Rejected]: translate('appointments_page.status.rejected'),
+  };
+
+  return <StatusWrapper status={status}>{STATUS_TEXTS[status]}</StatusWrapper>;
 }

--- a/src/components/appointments/appointment-status/styles.ts
+++ b/src/components/appointments/appointment-status/styles.ts
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import { TEXT_COLOR } from 'src/theme/colors';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+import typography from 'src/theme/typography';
+
+export const PendingStatus = styled('p')`
+  color: ${TEXT_COLOR.pending};
+  font-size: ${TYPOGRAPHY.base}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+`;
+
+export const ActiveStatus = styled('p')`
+  color: ${TEXT_COLOR.active};
+  font-size: ${TYPOGRAPHY.base}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+`;
+
+export const RejectedStatus = styled('p')`
+  color: ${TEXT_COLOR.rejected};
+  font-size: ${TYPOGRAPHY.base}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+`;

--- a/src/components/appointments/appointment-status/styles.ts
+++ b/src/components/appointments/appointment-status/styles.ts
@@ -2,27 +2,24 @@ import styled from '@emotion/styled';
 import { TEXT_COLOR } from 'src/theme/colors';
 import { TYPOGRAPHY } from 'src/theme/fonts';
 import typography from 'src/theme/typography';
+import { APPOINTMENT_STATUS } from 'src/constants';
 
-export const PendingStatus = styled('p')`
-  color: ${TEXT_COLOR.pending};
+export const StatusWrapper = styled.p<{ status: string }>`
   font-size: ${TYPOGRAPHY.base}px;
   font-weight: ${typography.fontWeightMedium};
   line-height: 1.5;
   letter-spacing: 0.15px;
-`;
+  color: ${(props): string => {
+    const colorMap: Record<string, string> = {
+      [APPOINTMENT_STATUS.Pending]: TEXT_COLOR.pending,
+      [APPOINTMENT_STATUS.Accepted]: TEXT_COLOR.active,
+      [APPOINTMENT_STATUS.Active]: TEXT_COLOR.active,
+      [APPOINTMENT_STATUS.Completed]: TEXT_COLOR.active,
+      [APPOINTMENT_STATUS.Ongoing]: TEXT_COLOR.active,
+      [APPOINTMENT_STATUS.Virtual]: TEXT_COLOR.active,
+      [APPOINTMENT_STATUS.Rejected]: TEXT_COLOR.rejected,
+    };
 
-export const ActiveStatus = styled('p')`
-  color: ${TEXT_COLOR.active};
-  font-size: ${TYPOGRAPHY.base}px;
-  font-weight: ${typography.fontWeightMedium};
-  line-height: 1.5;
-  letter-spacing: 0.15px;
-`;
-
-export const RejectedStatus = styled('p')`
-  color: ${TEXT_COLOR.rejected};
-  font-size: ${TYPOGRAPHY.base}px;
-  font-weight: ${typography.fontWeightMedium};
-  line-height: 1.5;
-  letter-spacing: 0.15px;
+    return colorMap[props.status];
+  }};
 `;

--- a/src/components/appointments/appointments-list/AppointmentsList.tsx
+++ b/src/components/appointments/appointments-list/AppointmentsList.tsx
@@ -4,18 +4,18 @@ import { IconButton } from '@mui/material';
 import RightAction from 'src/assets/icons/RightAction';
 import AppointmentStatus from 'src/components/appointments/appointment-status/AppointmentStatus';
 import AppointmentDrawer from 'src/components/appointments/appointment-drawer/AppointmentDrawer';
-import { PropsType, AppointmentType } from 'src/components/appointments/types';
+import { AppointmentsProps} from 'src/components/appointments/types';
 import { APPOINTMENT_STATUS } from 'src/constants';
 
 import { Item, RejectedTitle, TextContainer, Title } from './styles';
 
-export default function AppointmentsList({ appointments }: PropsType): JSX.Element {
+export default function AppointmentsList({ appointments }: AppointmentsProps): JSX.Element {
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
-  const [selectedAppointment, setSelectedAppointment] = useState<AppointmentType | null>(null);
+  const [selectedAppointmentId, setSelectedAppointmentId] = useState<string | null>(null);
 
-  const handleDrawerOpen = (appointment: AppointmentType): void => {
+  const handleDrawerOpen = (appointmentId: string): void => {
     setIsDrawerOpen(true);
-    setSelectedAppointment(appointment);
+    setSelectedAppointmentId(appointmentId);
   };
   const handleDrawerClose = (): void => setIsDrawerOpen(false);
 
@@ -36,19 +36,19 @@ export default function AppointmentsList({ appointments }: PropsType): JSX.Eleme
             <IconButton
               edge="end"
               aria-label="open-drawer"
-              onClick={(): void => handleDrawerOpen(appointment)}
+              onClick={(): void => handleDrawerOpen(appointment.id)}
             >
               <RightAction />
             </IconButton>
           </Item>
         ))}
       </ul>
-      {selectedAppointment && (
+      {selectedAppointmentId && (
         <AppointmentDrawer
           isOpen={isDrawerOpen}
           setIsDrawerOpen={setIsDrawerOpen}
           onClose={handleDrawerClose}
-          selectedAppointment={selectedAppointment}
+          selectedAppointmentId={selectedAppointmentId}
         />
       )}
     </>

--- a/src/components/appointments/appointments-list/AppointmentsList.tsx
+++ b/src/components/appointments/appointments-list/AppointmentsList.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { IconButton } from '@mui/material';
+
+import RightAction from 'src/assets/icons/RightAction';
+import AppointmentStatus from 'src/components/appointments/appointment-status/AppointmentStatus';
+import AppointmentDrawer from 'src/components/appointments/appointment-drawer/AppointmentDrawer';
+import { PropsType, AppointmentType } from 'src/components/appointments/types';
+import { APPOINTMENT_STATUS } from 'src/constants';
+
+import { Item, RejectedTitle, TextContainer, Title } from './styles';
+
+export default function AppointmentsList({ appointments }: PropsType): JSX.Element {
+  const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
+  const [selectedAppointment, setSelectedAppointment] = useState<AppointmentType | null>(null);
+
+  const handleDrawerOpen = (appointment: AppointmentType): void => {
+    setIsDrawerOpen(true);
+    setSelectedAppointment(appointment);
+  };
+  const handleDrawerClose = (): void => setIsDrawerOpen(false);
+
+  return (
+    <>
+      <ul>
+        {appointments.map((appointment) => (
+          <Item key={appointment.id}>
+            <TextContainer>
+              {appointment.status === APPOINTMENT_STATUS.Rejected ? (
+                <RejectedTitle>{appointment.name}</RejectedTitle>
+              ) : (
+                <Title>{appointment.name}</Title>
+              )}
+
+              <AppointmentStatus status={appointment.status} />
+            </TextContainer>
+            <IconButton
+              edge="end"
+              aria-label="open-drawer"
+              onClick={(): void => handleDrawerOpen(appointment)}
+            >
+              <RightAction />
+            </IconButton>
+          </Item>
+        ))}
+      </ul>
+      {selectedAppointment && (
+        <AppointmentDrawer
+          isOpen={isDrawerOpen}
+          setIsDrawerOpen={setIsDrawerOpen}
+          onClose={handleDrawerClose}
+          selectedAppointment={selectedAppointment}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/appointments/appointments-list/styles.ts
+++ b/src/components/appointments/appointments-list/styles.ts
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+import { PRIMARY, SECONDARY } from 'src/theme/colors';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+import typography from 'src/theme/typography';
+
+export const Item = styled('li')`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid ${SECONDARY.light_gray};
+`;
+
+export const TextContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 288px;
+`;
+
+export const Title = styled('h3')`
+  color: ${PRIMARY.black};
+  font-size: ${TYPOGRAPHY.sm}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+  line-height: 1.6;
+  letter-spacing: 0.15px;
+`;
+
+export const RejectedTitle = styled('h3')`
+  color: ${SECONDARY.semi_gray};
+  font-size: ${TYPOGRAPHY.sm}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+  line-height: 1.6;
+  letter-spacing: 0.15px;
+`;

--- a/src/components/appointments/cancel-modal/CancelModal.tsx
+++ b/src/components/appointments/cancel-modal/CancelModal.tsx
@@ -1,0 +1,24 @@
+import { useLocales } from 'src/locales';
+import { Container, SubTitle, DoubleButtonBox, StyledButton, CancelBtn } from './styles';
+
+interface IProps {
+  onClose: () => void;
+}
+
+export default function CancelModal({ onClose }: IProps): JSX.Element {
+  const { translate } = useLocales();
+
+  return (
+    <Container>
+      <SubTitle>{translate('appointments_page.modal_subtitle')}</SubTitle>
+      <DoubleButtonBox>
+        <CancelBtn type="button" variant="outlined">
+          {translate('appointments_page.cancel_button')}
+        </CancelBtn>
+        <StyledButton type="button" variant="contained" onClick={onClose}>
+          {translate('appointments_page.back_button')}
+        </StyledButton>
+      </DoubleButtonBox>
+    </Container>
+  );
+}

--- a/src/components/appointments/cancel-modal/styles.ts
+++ b/src/components/appointments/cancel-modal/styles.ts
@@ -1,0 +1,41 @@
+import { styled, Button } from '@mui/material';
+import { SECONDARY, TEXT_COLOR } from 'src/theme/colors';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+import typography from 'src/theme/typography';
+
+export const Container = styled('div')`
+  width: 430px;
+`;
+
+export const SubTitle = styled('p')`
+  color: ${SECONDARY.gray_semi_transparent};
+  font-size: ${TYPOGRAPHY.xs}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.43;
+  letter-spacing: 0.17px;
+  margin-bottom: 8px;
+  text-align: center;
+  margin-bottom: 24px;
+`;
+
+export const DoubleButtonBox = styled('div')`
+  display: flex;
+  gap: 16px;
+`;
+
+export const CancelBtn = styled(Button)`
+  border-radius: 4px;
+  width: 100%;
+  color: ${TEXT_COLOR.error};
+  border-color: ${TEXT_COLOR.error};
+
+  &:hover {
+    background-color: ${SECONDARY.error_hover};
+    border: 1px solid ${TEXT_COLOR.error};
+  }
+`;
+
+export const StyledButton = styled(Button)`
+  border-radius: 4px;
+  width: 100%;
+`;

--- a/src/components/appointments/constants.ts
+++ b/src/components/appointments/constants.ts
@@ -1,1 +1,3 @@
 export const SMALL_CAREGIVER_AVATAR_SIZE = 48;
+
+export const DRAWER_DATE_FORMAT = 'dd MMM, HH:mm';

--- a/src/components/appointments/constants.ts
+++ b/src/components/appointments/constants.ts
@@ -1,0 +1,1 @@
+export const SMALL_CAREGIVER_AVATAR_SIZE = 48;

--- a/src/components/appointments/helpers.ts
+++ b/src/components/appointments/helpers.ts
@@ -1,0 +1,81 @@
+import { format } from 'date-fns';
+
+export const getMockCaregiverAvatar = (size: number): string =>
+  `https://picsum.photos/${size}/${size}`;
+
+export const getFormattedDate = (date: Date): string => format(date, 'dd MMM, HH:mm');
+
+export const mockedTasks = [
+  { id: 1, name: 'Task 1' },
+  { id: 2, name: 'Task 2' },
+  { id: 3, name: 'Task 3' },
+];
+
+export const mockedCaregiver = {
+  firstName: 'Smith',
+  lastName: 'Jacobs',
+  id: '111',
+};
+
+export const mockedAppointments = [
+  {
+    id: '1',
+    userId: '1',
+    caregiverInfoId: '1',
+    name: 'Comprehensive Medical Management Plan',
+    status: 'Pending confirmation',
+    type: 'One time',
+    location: 'USA',
+    startDate: new Date(),
+    endDate: new Date(),
+    timezone: 'UTC-3',
+  },
+  {
+    id: '2',
+    userId: '2',
+    caregiverInfoId: '2',
+    name: 'ADL and IADL Support Plan',
+    status: 'Active',
+    type: 'Recurring',
+    location: 'USA',
+    startDate: new Date(),
+    endDate: new Date(),
+    timezone: 'UTC-3',
+  },
+  {
+    id: '3',
+    userId: '3',
+    caregiverInfoId: '3',
+    name: 'ADL and IADL Support Plan',
+    status: 'Accepted',
+    type: 'One time',
+    location: 'USA',
+    startDate: new Date(),
+    endDate: new Date(),
+    timezone: 'UTC-3',
+  },
+  {
+    id: '5',
+    userId: '5',
+    caregiverInfoId: '5',
+    name: 'Cognitive Support Plan',
+    status: 'Virtual assessment',
+    type: 'Recurring',
+    location: 'USA',
+    startDate: new Date(),
+    endDate: new Date(),
+    timezone: 'UTC-3',
+  },
+  {
+    id: '4',
+    userId: '4',
+    caregiverInfoId: '4',
+    name: 'Cognitive Support Plan',
+    status: 'Rejected',
+    type: 'Recurring',
+    location: 'USA',
+    startDate: new Date(),
+    endDate: new Date(),
+    timezone: 'UTC-3',
+  },
+];

--- a/src/components/appointments/helpers.ts
+++ b/src/components/appointments/helpers.ts
@@ -6,18 +6,6 @@ export const getMockCaregiverAvatar = (size: number): string =>
 
 export const getFormattedDate = (date: Date): string => format(date, DRAWER_DATE_FORMAT);
 
-export const mockedTasks = [
-  { id: 1, name: 'Task 1' },
-  { id: 2, name: 'Task 2' },
-  { id: 3, name: 'Task 3' },
-];
-
-export const mockedCaregiver = {
-  firstName: 'Smith',
-  lastName: 'Jacobs',
-  id: '111',
-};
-
 export const mockedAppointments = [
   {
     id: '1',
@@ -54,11 +42,16 @@ export const mockedAppointments = [
     startDate: new Date(),
     endDate: new Date(),
     timezone: 'UTC-3',
+    details: 'ref',
+    payment: 5,
+    activityNote: 'activityNoteactivityNote',
+    diagnosisNote: 'diagnosisNotediagnosisNote',
+    capabilityNote: 'capabilityNotecapabilityNote',
   },
   {
-    id: '5',
-    userId: '5',
-    caregiverInfoId: '5',
+    id: '4',
+    userId: '4',
+    caregiverInfoId: '4',
     name: 'Cognitive Support Plan',
     status: 'Virtual assessment',
     type: 'Recurring',
@@ -68,9 +61,9 @@ export const mockedAppointments = [
     timezone: 'UTC-3',
   },
   {
-    id: '4',
-    userId: '4',
-    caregiverInfoId: '4',
+    id: '5',
+    userId: '5',
+    caregiverInfoId: '5',
     name: 'Cognitive Support Plan',
     status: 'Rejected',
     type: 'Recurring',
@@ -80,3 +73,48 @@ export const mockedAppointments = [
     timezone: 'UTC-3',
   },
 ];
+
+export const mockedAppointment = {
+  id: '1',
+  userId: '4a6264dd-9280-4884-bc5d-fc0b9ddf9640',
+  caregiverInfoId: '227ee80d-217a-4b1d-9cb5-44d9660f88ad',
+  name: 'Comprehensive Medical Management Plan',
+  status: 'Pending confirmation',
+  type: 'One time',
+  location: 'USA',
+  startDate: new Date(),
+  endDate: new Date(),
+  timezone: 'UTC-3',
+  details: 'ref',
+  payment: 5,
+  activityNote: 'activityNoteactivityNote',
+  diagnosisNote: 'diagnosisNotediagnosisNote',
+  capabilityNote: 'capabilityNotecapabilityNote',
+  weekday: '["Monday","Sunday"]',
+  seekerTasks: [
+    {
+      appointmentId: '11',
+      name: 'task 1',
+    },
+    {
+      appointmentId: '22',
+      name: 'task 2',
+    },
+    {
+      appointmentId: '33',
+      name: 'task 3',
+    },
+    {
+      appointmentId: '44',
+      name: 'task 4',
+    },
+  ],
+  caregiverInfo: {
+    id: '123',
+    user: {
+      id: '1234',
+      firstName: 'Vova',
+      lastName: 'Qwerty',
+    },
+  },
+};

--- a/src/components/appointments/helpers.ts
+++ b/src/components/appointments/helpers.ts
@@ -1,9 +1,10 @@
 import { format } from 'date-fns';
+import { DRAWER_DATE_FORMAT } from './constants';
 
 export const getMockCaregiverAvatar = (size: number): string =>
   `https://picsum.photos/${size}/${size}`;
 
-export const getFormattedDate = (date: Date): string => format(date, 'dd MMM, HH:mm');
+export const getFormattedDate = (date: Date): string => format(date, DRAWER_DATE_FORMAT);
 
 export const mockedTasks = [
   { id: 1, name: 'Task 1' },

--- a/src/components/appointments/styles.ts
+++ b/src/components/appointments/styles.ts
@@ -1,0 +1,45 @@
+import { Button, styled } from '@mui/material';
+import { PRIMARY, SECONDARY } from 'src/theme/colors';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+import typography from 'src/theme/typography';
+import { HEADER } from 'src/config-global';
+
+export const Background = styled('div')`
+  background-color: ${PRIMARY.light_main};
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding-top: ${HEADER.MAIN_HEIGHT}px;
+`;
+
+export const Container = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  width: 720px;
+  background-color: ${PRIMARY.white};
+  border-radius: 4px;
+  box-shadow: 0px 4px 4px 0px ${SECONDARY.gray_shadow};
+  margin-top: 16px;
+  padding: 16px;
+`;
+
+export const HeadContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const Title = styled('h2')`
+  color: ${PRIMARY.black};
+  font-size: ${TYPOGRAPHY.l}px;
+  font-weight: ${typography.fontWeightMedium};
+  line-height: 1.5;
+  letter-spacing: 0.15px;
+`;
+
+export const StyledButton = styled(Button)`
+  border-radius: 4px;
+  height: 42px;
+`;

--- a/src/components/appointments/types.ts
+++ b/src/components/appointments/types.ts
@@ -1,0 +1,22 @@
+export type AppointmentType = {
+  id: string;
+  userId: string;
+  caregiverInfoId: string;
+  name: string;
+  type: string;
+  status: string;
+  details?: string;
+  location: string;
+  activityNote?: string;
+  diagnosisNote?: string;
+  capabilityNote?: string;
+  startDate: Date;
+  endDate: Date;
+  timezone: string;
+  weekdays?: string[];
+  payment?: number;
+};
+
+export type PropsType = {
+  appointments: AppointmentType[];
+};

--- a/src/components/appointments/types.ts
+++ b/src/components/appointments/types.ts
@@ -1,4 +1,4 @@
-export type AppointmentType = {
+export type Appointment = {
   id: string;
   userId: string;
   caregiverInfoId: string;
@@ -17,6 +17,41 @@ export type AppointmentType = {
   payment?: number;
 };
 
-export type PropsType = {
-  appointments: AppointmentType[];
+export type AppointmentsProps = {
+  appointments: Appointment[];
+};
+
+export type SeekerTask = {
+  appointmentId: string;
+  name: string;
+};
+
+export type CaregiverInfo = {
+  id: string;
+  user: {
+    id: string;
+    firstName: string;
+    lastName: string;
+  };
+};
+
+export type DetailedAppointment = {
+  id: string;
+  userId: string;
+  caregiverInfoId: string;
+  name: string;
+  type: string;
+  status: string;
+  details?: string;
+  location: string;
+  activityNote?: string;
+  diagnosisNote?: string;
+  capabilityNote?: string;
+  startDate: Date;
+  endDate: Date;
+  timezone: string;
+  weekdays?: string[];
+  payment?: number;
+  seekerTasks: SeekerTask[];
+  caregiverInfo: CaregiverInfo;
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -30,3 +30,13 @@ export const weekDays = [
   abbr: string;
   value: daySelectedType;
 }[];
+
+export const APPOINTMENT_STATUS = {
+  Pending: 'Pending confirmation',
+  Rejected: 'Rejected',
+  Accepted: 'Accepted',
+  Virtual: 'Virtual assessment',
+  Active: 'Active',
+  Ongoing: 'Ongoing',
+  Completed: 'Completed',
+};

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -491,7 +491,7 @@ const en = {
     cancel_button: 'Cancel',
     cancel_appointment_button: 'Cancel appointment',
     virtual_button: 'Virtual assessment',
-    signIn_button: 'Sign in the contract',
+    contract_button: 'View the signed contract',
     back_button: 'Back to the appointment',
     modal_title: 'Cancel the appointment',
     modal_subtitle: 'Are you sure you would like to cancel the appointment?',

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -9,7 +9,7 @@ import { MAX_CHARACTERS_LENGTH } from 'src/constants';
 import { CONFIRM_NOTE_MAX_LENGTH } from 'src/components/confirm-appointment/constants';
 
 const en = {
-  app_title: 'App title',
+  app_title: 'CtrlChamps',
   btn_next: 'next',
   date: 'Date',
   logo_first_part: 'Ctrl',
@@ -483,6 +483,33 @@ const en = {
           completely_dependent: 'Completly Dependent',
         },
       },
+    },
+  },
+  appointments_page: {
+    page_title: 'Appointments',
+    create_button: 'Create an Appointment',
+    cancel_button: 'Cancel',
+    cancel_appointment_button: 'Cancel appointment',
+    virtual_button: 'Virtual assessment',
+    signIn_button: 'Sign in the contract',
+    back_button: 'Back to the appointment',
+    modal_title: 'Cancel the appointment',
+    modal_subtitle: 'Are you sure you would like to cancel the appointment?',
+    status: {
+      pending: 'Pending confirmation',
+      rejected: 'Rejected',
+      accepted: 'Accepted',
+      virtual: 'Virtual assessment',
+      active: 'Active',
+      ongoing: 'Ongoing',
+      completed: 'Completed',
+    },
+    drawer: {
+      caregiver: 'Caregiver',
+      date: 'Date & Time',
+      tasks: 'Tasks',
+      details: 'Additional Details',
+      details_empty: 'Nothing specific',
     },
   },
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,10 @@
 // next
 import Head from 'next/head';
+import Appointments from 'src/components/appointments/Appointments';
 import BookAppointment from 'src/components/book-appointment/BookAppointment';
 import MainHeader from 'src/components/reusable/header/MainHeader';
 import { useLocales } from 'src/locales';
+import { mockedAppointments } from 'src/components/appointments/helpers';
 
 export default function HomePage(): JSX.Element {
   const { translate } = useLocales();
@@ -13,7 +15,11 @@ export default function HomePage(): JSX.Element {
         <title>{translate('app_title')}</title>
       </Head>
       <MainHeader />
-      <BookAppointment />
+      {mockedAppointments.length > 0 ? (
+        <Appointments appointments={mockedAppointments} />
+      ) : (
+        <BookAppointment />
+      )}
     </>
   );
 }

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -16,8 +16,13 @@ export const SECONDARY = {
   gray_shadow: 'rgba(0, 0, 0, 0.1)',
   semi_gray: 'rgba(0, 0, 0, 0.5)',
   selected: '#b8ffef63',
+  drawer_background: 'rgba(8, 188, 184, 0.04)',
+  error_hover: 'rgba(198, 40, 40, 0.08)',
 };
 
 export const TEXT_COLOR = {
   error: '#C62828',
+  pending: 'rgba(255, 165, 0, 0.87)',
+  active: 'rgba(0, 128, 0, 0.87)',
+  rejected: 'rgba(255, 0, 0, 0.87)',
 };

--- a/src/theme/fonts.ts
+++ b/src/theme/fonts.ts
@@ -6,6 +6,7 @@ export const TYPOGRAPHY = {
   base_sm: 18,
   sm: 20,
   md: 24,
+  l: 32,
   lg: 34,
   xl: 48,
   xxl: 60,


### PR DESCRIPTION
## Describe your changes

add Appointments component;
add Appointment status component;
add Appointments list component;
add Cancel Modal;
add Appointment Drawer Component for all statuses types; 
used mocked data, because we don't have BE part for this component now

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-127)

Appointments page:
<img width="594" alt="Снимок экрана 2023-12-08 192053" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/9e097390-4d25-43a1-82d5-816e670804d6">

Drawer for 'Pending confirmation' status:
<img width="498" alt="Снимок экрана 2023-12-08 191620" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/29df77c6-af5e-4e85-b52e-fee88bf6c3d4">

Drawer for 'Active' status:
<img width="372" alt="Снимок экрана 2023-12-10 141402" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/30f36656-50d6-46fb-8d95-e2b0ab86fe13">

Drawer for 'Accepted' status:
<img width="449" alt="Снимок экрана 2023-12-08 191730" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/c9e66a14-661b-4c34-9ce4-40d40a5cc1d0">

Drawer for 'Virtual assessment' status:
<img width="446" alt="Снимок экрана 2023-12-08 191743" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/97d5668b-dbdb-4f50-bb37-a50cf2c4bcd8">

Drawer for 'Rejected' status:
<img width="467" alt="Снимок экрана 2023-12-08 192102" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/db1c5f06-8c71-40d4-870b-be18b953c516">

Cancel appointment modal:
<img width="435" alt="Снимок экрана 2023-12-08 191629" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/e672a5e5-9f76-4feb-9e9e-6ba3f47d7cf2">


### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
