### PR TITLE
fix: start date cannot be in future

### DIFF
--- a/src/components/profile/profile-qualification/certificate-form/validation.ts
+++ b/src/components/profile/profile-qualification/certificate-form/validation.ts
@@ -1,4 +1,5 @@
 import { ObjectSchema, boolean, date, object, string } from 'yup';
+import { endOfDay, isAfter } from 'date-fns';
 
 import { ProfileQualityFormValues } from 'src/components/profile/profile-qualification/types';
 import { MAX_CHARACTERS_LENGTH, URL_PATTERN } from 'src/constants';
@@ -25,7 +26,13 @@ export const useProfileQualificationSchema = (): ObjectSchema<ProfileQualityForm
           return URL_PATTERN.test(value);
         }
       ),
-    dateIssued: date().required(translate('profileQualification.startDateRequired')),
+    dateIssued: date()
+      .required(translate('profileQualification.startDateRequired'))
+      .test(
+        'is-future-date',
+        translate('profileQualification.startDateCannotBeInFuture'),
+        (value) => !isAfter(value, endOfDay(new Date()))
+      ),
     isExpirationDateDisabled: boolean().required(),
     expirationDate: date().when('isExpirationDateDisabled', {
       is: false,

--- a/src/components/profile/profile-qualification/certificate-form/validation.ts
+++ b/src/components/profile/profile-qualification/certificate-form/validation.ts
@@ -1,5 +1,5 @@
 import { ObjectSchema, boolean, date, object, string } from 'yup';
-import { endOfDay, isAfter } from 'date-fns';
+import { isAfter } from 'date-fns';
 
 import { ProfileQualityFormValues } from 'src/components/profile/profile-qualification/types';
 import { MAX_CHARACTERS_LENGTH, URL_PATTERN } from 'src/constants';
@@ -31,7 +31,7 @@ export const useProfileQualificationSchema = (): ObjectSchema<ProfileQualityForm
       .test(
         'is-future-date',
         translate('profileQualification.startDateCannotBeInFuture'),
-        (value) => !isAfter(value, endOfDay(new Date()))
+        (value) => !isAfter(value, new Date())
       ),
     isExpirationDateDisabled: boolean().required(),
     expirationDate: date().when('isExpirationDateDisabled', {

--- a/src/components/profile/profile-qualification/certificate-form/validation.ts
+++ b/src/components/profile/profile-qualification/certificate-form/validation.ts
@@ -4,6 +4,7 @@ import { isAfter } from 'date-fns';
 import { ProfileQualityFormValues } from 'src/components/profile/profile-qualification/types';
 import { MAX_CHARACTERS_LENGTH, URL_PATTERN } from 'src/constants';
 import { useLocales } from 'src/locales';
+import { MAX_CERTIFICATE_DATE } from 'src/components/profile/profile-qualification/certificate-form/constants';
 
 export const useProfileQualificationSchema = (): ObjectSchema<ProfileQualityFormValues> => {
   const { translate } = useLocales();
@@ -31,7 +32,7 @@ export const useProfileQualificationSchema = (): ObjectSchema<ProfileQualityForm
       .test(
         'is-future-date',
         translate('profileQualification.startDateCannotBeInFuture'),
-        (value) => !isAfter(value, new Date())
+        (value) => !isAfter(value, MAX_CERTIFICATE_DATE)
       ),
     isExpirationDateDisabled: boolean().required(),
     expirationDate: date().when('isExpirationDateDisabled', {

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -200,6 +200,8 @@ const en = {
     startDateRequired: 'Start date is required',
     expirationDate: 'Expiration date is required',
 
+    startDateCannotBeInFuture: 'Start date cannot be in future',
+
     mainTitle:
       'Please specify your experience and feel free to attach any document to proof your certification',
     subTitle: 'Added Certificate(s)',


### PR DESCRIPTION
## Describe your changes

- I added validation for start date input (we had validation only for the date picker).

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-207?atlOrigin=eyJpIjoiNTllN2ZiNjBiMDEzNGNjNTg5MDZiYTRkZmRmYzdiOGUiLCJwIjoiaiJ9)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.