### PR TITLE
fix: adjust main header logic

### DIFF
--- a/src/components/appointments/AppointmentsPage.tsx
+++ b/src/components/appointments/AppointmentsPage.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import { useState } from 'react';
 
 import Appointments from 'src/components/appointments/Appointments';
 import BookAppointment from 'src/components/book-appointment/BookAppointment';
@@ -8,13 +7,9 @@ import MainHeader from 'src/components/reusable/header/MainHeader';
 import { USER_ROLE } from 'src/constants';
 import { useLocales } from 'src/locales';
 import { useGetAllAppointmentsQuery } from 'src/redux/api/appointmentApi';
-import { TabType } from '../reusable/header/enums';
-import { ActiveTab } from '../reusable/header/types';
 
 export default function AppointmentsPage(): JSX.Element | null {
   const { translate } = useLocales();
-  const [activeTab, setActiveTab] = useState<ActiveTab>(TabType.mainPage);
-
   const { data: appointments, isSuccess, isLoading } = useGetAllAppointmentsQuery();
 
   if (isLoading) return null;
@@ -24,7 +19,7 @@ export default function AppointmentsPage(): JSX.Element | null {
       <Head>
         <title>{translate('app_title')}</title>
       </Head>
-      <MainHeader activeTab={activeTab} setActiveTab={setActiveTab} />
+      <MainHeader />
       {isSuccess && appointments.length > 0 ? (
         <Appointments appointments={appointments} />
       ) : (

--- a/src/components/caregiver-schedule/CaregiverSchedulePage.tsx
+++ b/src/components/caregiver-schedule/CaregiverSchedulePage.tsx
@@ -6,20 +6,21 @@ import CaregiverSchedule from 'src/components/caregiver-schedule/CaregiverSchedu
 import MainHeader from 'src/components/reusable/header/MainHeader';
 import { USER_ROLE } from 'src/constants';
 import { useLocales } from 'src/locales';
-import { TabType } from '../reusable/header/enums';
-import { ActiveTab } from '../reusable/header/types';
 
 export default function CaregiverSchedulePage(): JSX.Element | null {
   const { translate } = useLocales();
-  const [activeTab, setActiveTab] = useState<ActiveTab>(null);
+  const [isCalendarVisible, setIsCalendarVisible] = useState<boolean>(false);
 
   return (
     <PrivateRoute allowedRole={USER_ROLE.Caregiver}>
       <Head>
         <title>{translate('app_title')}</title>
       </Head>
-      <MainHeader activeTab={activeTab} setActiveTab={setActiveTab} />
-      <CaregiverSchedule isCalendarVisible={activeTab === TabType.mainPage} />
+      <MainHeader
+        isCalendarVisible={isCalendarVisible}
+        setIsCalendarVisible={setIsCalendarVisible}
+      />
+      <CaregiverSchedule isCalendarVisible={isCalendarVisible} />
     </PrivateRoute>
   );
 }

--- a/src/components/reusable/header/MainHeader.tsx
+++ b/src/components/reusable/header/MainHeader.tsx
@@ -1,10 +1,9 @@
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import NotificationsIcon from '@mui/icons-material/Notifications';
 import { Avatar } from '@mui/material';
 import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction, useState } from 'react';
 import AppointmentsIcon from 'src/assets/icons/AppointmentsIcon';
-import NotificationIcon from 'src/assets/icons/NotificationIcon';
-import { IconWrapper } from 'src/components/confirm-appointment/style';
 import { USER_ROLE } from 'src/constants';
 import { useLocales } from 'src/locales';
 import { useTypedSelector } from 'src/redux/store';
@@ -15,6 +14,7 @@ import {
   Arrow,
   AvatarWrapper,
   FirstPart,
+  IconWrapper,
   Logo,
   LogoSection,
   MainHeaderWrapper,
@@ -46,6 +46,10 @@ export default function MainHeader({
 
   const openMenu = (): void => setIsMenuVisible(!isMenuVisible);
 
+  const viewNotifications = (): void => {
+    if (route !== ROUTES.notifications) push(ROUTES.notifications);
+  };
+
   const chooseAppointmentsTab = (): void => {
     if (route !== ROUTES.home) {
       push(ROUTES.home);
@@ -74,8 +78,11 @@ export default function MainHeader({
         </AppointmentsSection>
       </LogoSection>
       <MenuSection>
-        <IconWrapper>
-          <NotificationIcon />
+        <IconWrapper
+          onClick={viewNotifications}
+          className={route === ROUTES.notifications ? 'active' : ''}
+        >
+          <NotificationsIcon />
         </IconWrapper>
         <ProfileSection>
           <AvatarWrapper>

--- a/src/components/reusable/header/MainHeader.tsx
+++ b/src/components/reusable/header/MainHeader.tsx
@@ -1,22 +1,19 @@
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Avatar } from '@mui/material';
+import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction, useState } from 'react';
 import AppointmentsIcon from 'src/assets/icons/AppointmentsIcon';
-import ChatIcon from 'src/assets/icons/ChatIcon';
 import NotificationIcon from 'src/assets/icons/NotificationIcon';
 import { IconWrapper } from 'src/components/confirm-appointment/style';
 import { USER_ROLE } from 'src/constants';
 import { useLocales } from 'src/locales';
 import { useTypedSelector } from 'src/redux/store';
 import { ROUTES } from 'src/routes';
-import { TabType } from './enums';
 import {
   AppointmentsSection,
   AppointmentsText,
   Arrow,
   AvatarWrapper,
-  ChatSection,
-  ChatText,
   FirstPart,
   Logo,
   LogoSection,
@@ -26,15 +23,18 @@ import {
   ProfileSection,
   SecondPart,
 } from './styles';
-import { ActiveTab } from './types';
 
 type Props = {
-  activeTab: ActiveTab;
-  setActiveTab: Dispatch<SetStateAction<ActiveTab>>;
+  isCalendarVisible?: boolean;
+  setIsCalendarVisible?: Dispatch<SetStateAction<boolean>>;
 };
 
-export default function MainHeader({ activeTab, setActiveTab }: Props): JSX.Element | null {
+export default function MainHeader({
+  isCalendarVisible,
+  setIsCalendarVisible,
+}: Props): JSX.Element | null {
   const { translate } = useLocales();
+  const { push, route } = useRouter();
 
   const user = useTypedSelector((state) => state.user.user);
 
@@ -45,7 +45,16 @@ export default function MainHeader({ activeTab, setActiveTab }: Props): JSX.Elem
   const { role, firstName, lastName } = user;
 
   const openMenu = (): void => setIsMenuVisible(!isMenuVisible);
-  const chooseActiveTab = (value: ActiveTab): void => setActiveTab(value);
+
+  const chooseAppointmentsTab = (): void => {
+    if (route !== ROUTES.home) {
+      push(ROUTES.home);
+    }
+
+    if (role === USER_ROLE.Caregiver && setIsCalendarVisible) {
+      setIsCalendarVisible(!isCalendarVisible);
+    }
+  };
 
   return (
     <MainHeaderWrapper>
@@ -55,21 +64,14 @@ export default function MainHeader({ activeTab, setActiveTab }: Props): JSX.Elem
           <SecondPart>{translate('logo_second_part')}</SecondPart>
         </Logo>
         <AppointmentsSection
-          onClick={(): void => chooseActiveTab(TabType.mainPage)}
-          className={activeTab === TabType.mainPage ? 'active_tab' : ''}
+          onClick={chooseAppointmentsTab}
+          className={route === ROUTES.home ? 'active_tab' : ''}
         >
           <AppointmentsIcon />
           <AppointmentsText>
             {role === USER_ROLE.Seeker ? translate('appointments') : translate('schedule')}
           </AppointmentsText>
         </AppointmentsSection>
-        <ChatSection
-          onClick={(): void => chooseActiveTab(TabType.chat)}
-          className={activeTab === TabType.chat ? 'active_tab' : ''}
-        >
-          <ChatIcon />
-          <ChatText>{translate('chats')}</ChatText>
-        </ChatSection>
       </LogoSection>
       <MenuSection>
         <IconWrapper>

--- a/src/components/reusable/header/enums.ts
+++ b/src/components/reusable/header/enums.ts
@@ -1,4 +1,0 @@
-export enum TabType {
-  mainPage = 'mainPage',
-  chat = 'chats',
-}

--- a/src/components/reusable/header/styles.ts
+++ b/src/components/reusable/header/styles.ts
@@ -133,7 +133,7 @@ const SecondPart = styled.p`
 const MenuSection = styled.div`
   display: flex;
   align-items: center;
-  gap: 32px;
+  gap: 20px;
 `;
 
 const ProfileSection = styled.div`
@@ -160,6 +160,16 @@ const AvatarWrapper = styled.div`
 
 const IconWrapper = styled.div`
   cursor: pointer;
+  padding: 12.5px 10px;
+  border-bottom: 3px solid transparent;
+  &:hover {
+    color: ${PRIMARY.dark_main};
+  }
+
+  &.active {
+    color: ${PRIMARY.navy};
+    border-bottom: 3px solid ${PRIMARY.navy};
+  }
 `;
 
 const Arrow = styled.div`

--- a/src/pages/account-details/index.tsx
+++ b/src/pages/account-details/index.tsx
@@ -1,17 +1,14 @@
-import { useState } from 'react';
 import Head from 'next/head';
 
+import AccountDetails from 'src/components/account-details/AccountDetails';
 import { PrivateRoute } from 'src/components/private-route/PrivateRoute';
 import MainHeader from 'src/components/reusable/header/MainHeader';
-import AccountDetails from 'src/components/account-details/AccountDetails';
 import { useLocales } from 'src/locales';
-import { ActiveTab } from 'src/components/reusable/header/types';
-import { useTypedSelector } from 'src/redux/store';
 import { useGetUserInfoQuery } from 'src/redux/api/userApi';
+import { useTypedSelector } from 'src/redux/store';
 
 export default function CaregiverSchedulePage(): JSX.Element | null {
   const { translate } = useLocales();
-  const [activeTab, setActiveTab] = useState<ActiveTab>(null);
   const userId = useTypedSelector((state) => state.user.user?.id);
 
   const { data: userInfo, isLoading, isSuccess } = useGetUserInfoQuery(userId);
@@ -23,7 +20,7 @@ export default function CaregiverSchedulePage(): JSX.Element | null {
       <Head>
         <title>{translate('accountDetails.title')}</title>
       </Head>
-      <MainHeader activeTab={activeTab} setActiveTab={setActiveTab} />
+      <MainHeader />
       {isSuccess && <AccountDetails user={userInfo} />}
     </PrivateRoute>
   );

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -11,4 +11,5 @@ export const ROUTES = {
   appointments: '/appointments',
   profile: '/profile',
   account_details: '/account-details',
+  notifications: '/notifications',
 };


### PR DESCRIPTION
## Describe your changes

- I adjusted main header so that on 'appointments/schedule' onclick, the user was redirected to the respective page and could see his/her appointments. Also, adjusted the logic on current pages. Removed 'chats' tab as we are not sure if we will have time to implement this feature. Added styles and redirect for notification icon.

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.

