### PR TITLE
feat: add review activity log

### DIFF
--- a/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
+++ b/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
@@ -39,10 +39,13 @@ import {
 import PriorityIcon from 'src/assets/icons/PriorityIcon';
 
 import { UserRole } from 'src/redux/slices/userSlice';
+import { AssessmentPurpose } from '../virtual-assessment-modal/enums';
 import ActivityLogModal from './activity-log-modal/ActivityLogModal';
 import { isActivityLogReviewedShown, isActivityLogShown } from './activity-log-modal/helpers';
 import { useAppointmentDrawer } from './hooks';
 import AppointmentDrawerLocation from './location/AppointmentDrawerLocation';
+import ReviewActivityLogModal from './review-activity-log-modal/ReviewActivityLogModal';
+import { getLatestPendingActivityLog } from './review-activity-log-modal/helpers';
 import {
   ActivityLogBlock,
   AppointmentName,
@@ -63,7 +66,6 @@ import {
   Task,
   TaskList,
 } from './styles';
-import { AssessmentPurpose } from '../virtual-assessment-modal/enums';
 
 interface AppointmentsDrawerProps {
   role: string;
@@ -91,6 +93,7 @@ export default function AppointmentDrawer({
     isCompleteModalOpen,
     isAgreementModalOpen,
     isActivityLogModalOpen,
+    isReviewActivityLogModalOpen,
     isVirtualAssessmentModalOpen,
     isVirtualAssessmentSuccessOpen,
     isTermsAccepted,
@@ -105,6 +108,8 @@ export default function AppointmentDrawer({
     handleAgreementModalClose,
     handleActivityLogModalClose,
     handleActivityLogModalOpen,
+    handleReviewActivityLogModalClose,
+    handleReviewActivityLogModalOpen,
     handleVirtualAssessmentModalOpen,
     handleVirtualAssessmentModalClose,
     handleVirtualAssessmentSuccessModalClose,
@@ -265,7 +270,12 @@ export default function AppointmentDrawer({
                     {translate('appointments_page.activityLog')}
                   </Button>
                 )}
-
+              {!!getLatestPendingActivityLog(appointment.activityLog) &&
+                role === USER_ROLE.Seeker && (
+                  <Button variant="outlined" onClick={handleReviewActivityLogModalOpen}>
+                    {translate('appointments_page.reviewActivityLog')}
+                  </Button>
+                )}
               {isActivityLogReviewedShown(appointment, role as UserRole) && (
                 <DisabledText>
                   <PriorityIcon />
@@ -467,6 +477,14 @@ export default function AppointmentDrawer({
           appointmentId={appointment.id}
           onClose={handleActivityLogModalClose}
           seekerTasks={appointment.seekerTasks}
+        />
+      )}
+
+      {isReviewActivityLogModalOpen && (
+        <ReviewActivityLogModal
+          isOpen={isReviewActivityLogModalOpen}
+          activityLog={appointment.activityLog}
+          onClose={handleReviewActivityLogModalClose}
         />
       )}
 

--- a/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
+++ b/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
@@ -94,7 +94,6 @@ export default function AppointmentDrawer({
     isAgreementModalOpen,
     isActivityLogModalOpen,
     isReviewActivityLogModalOpen,
-    virtualAssessment,
     isVirtualAssessmentModalOpen,
     isVirtualAssessmentSuccessOpen,
     isTermsAccepted,
@@ -477,7 +476,6 @@ export default function AppointmentDrawer({
           isOpen={isVirtualAssessmentModalOpen}
           switchModalVisibility={handleVirtualAssessmentModalClose}
           openDrawer={openOriginalAppointment}
-          virtualAssessment={virtualAssessment}
           closeDrawer={closeOriginalAppointment}
         />
       )}
@@ -505,7 +503,6 @@ export default function AppointmentDrawer({
           isOpen={isVirtualAssessmentModalOpen}
           switchModalVisibility={handleVirtualAssessmentModalClose}
           openDrawer={openOriginalAppointment}
-          virtualAssessment={virtualAssessment}
           closeDrawer={closeOriginalAppointment}
         />
       )}

--- a/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
+++ b/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
@@ -38,8 +38,8 @@ import {
 
 import PriorityIcon from 'src/assets/icons/PriorityIcon';
 
+import { AssessmentPurpose } from 'src/components/appointments/virtual-assessment-modal/enums';
 import { UserRole } from 'src/redux/slices/userSlice';
-import { AssessmentPurpose } from '../virtual-assessment-modal/enums';
 import ActivityLogModal from './activity-log-modal/ActivityLogModal';
 import { isActivityLogReviewedShown, isActivityLogShown } from './activity-log-modal/helpers';
 import { useAppointmentDrawer } from './hooks';

--- a/src/components/appointments/appointment-drawer/activity-log-modal/helpers.ts
+++ b/src/components/appointments/appointment-drawer/activity-log-modal/helpers.ts
@@ -1,6 +1,7 @@
 import { format, getHours, getMinutes, isToday, isWithinInterval, parseISO } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 import { APPOINTMENT_STATUS, APPOINTMENT_TYPE, USER_ROLE } from 'src/constants';
+import { ActivityLogStatus } from 'src/redux/api/activityLogApi';
 import { DetailedAppointment } from 'src/redux/api/appointmentApi';
 import { UserRole } from 'src/redux/slices/userSlice';
 import { getISODateWithoutUTC } from 'src/utils/getISODateWithoutUTC';
@@ -123,6 +124,14 @@ export const isActivityLogReviewedShown = (
   const now = utcToZonedTime(new Date(), timezone);
 
   if (!isWithinAppointmentInterval(now, startDate, endDate)) return false;
+
+  if (
+    role === USER_ROLE.Seeker &&
+    (status === APPOINTMENT_STATUS.Completed || status === APPOINTMENT_STATUS.Active) &&
+    activityLog.every((item) => item.status !== ActivityLogStatus.Pending)
+  ) {
+    return true;
+  }
 
   if (activityLog.length && role === USER_ROLE.Caregiver && type === APPOINTMENT_TYPE.OneTime) {
     return true;

--- a/src/components/appointments/appointment-drawer/activity-log-modal/styles.ts
+++ b/src/components/appointments/appointment-drawer/activity-log-modal/styles.ts
@@ -1,5 +1,5 @@
 import { Button, Typography, styled } from '@mui/material';
-import { SECONDARY, TEXT_COLOR } from 'src/theme/colors';
+import { SECONDARY } from 'src/theme/colors';
 import { TYPOGRAPHY } from 'src/theme/fonts';
 import typography from 'src/theme/typography';
 import { Task, TaskList } from '../styles';
@@ -12,18 +12,6 @@ export const DoubleButtonBox = styled('div')`
   flex-direction: column;
   display: flex;
   gap: 16px;
-`;
-
-export const CancelBtn = styled(Button)`
-  border-radius: 4px;
-  width: 100%;
-  color: ${TEXT_COLOR.error};
-  border-color: ${TEXT_COLOR.error};
-
-  &:hover {
-    background-color: ${SECONDARY.error_hover};
-    border: 1px solid ${TEXT_COLOR.error};
-  }
 `;
 
 export const StyledTitle = styled(Typography)`

--- a/src/components/appointments/appointment-drawer/hooks.ts
+++ b/src/components/appointments/appointment-drawer/hooks.ts
@@ -1,10 +1,6 @@
-import { useState, Dispatch, SetStateAction } from 'react';
-import { useGetAppointmentQuery, DetailedAppointment } from 'src/redux/api/appointmentApi';
-import {
-  useGetVirtualAssessmentInfoQuery,
-  VirtualAssessment,
-} from 'src/redux/api/virtualAssessmentApi';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { USER_ROLE } from 'src/constants';
+import { DetailedAppointment, useGetAppointmentQuery } from 'src/redux/api/appointmentApi';
 import { getFormattedDate } from '../helpers';
 
 interface IProps {
@@ -23,7 +19,6 @@ type ReturnType = {
   isVirtualAssessmentSuccessOpen: boolean;
   isTermsAccepted: boolean;
   isLoading: boolean;
-  virtualAssessment: VirtualAssessment | undefined;
   appointment: DetailedAppointment | undefined;
   formattedStartDate: string | undefined;
   handleCancelModalOpen: () => void;
@@ -62,7 +57,6 @@ export function useAppointmentDrawer({
   const [isTermsAccepted, setIsTermsAccepted] = useState<boolean>(false);
 
   const { data: appointment, isLoading } = useGetAppointmentQuery(selectedAppointmentId);
-  const { data: virtualAssessment } = useGetVirtualAssessmentInfoQuery(selectedAppointmentId);
 
   const formattedStartDate = appointment && getFormattedDate(appointment.startDate);
 
@@ -153,7 +147,6 @@ export function useAppointmentDrawer({
     isVirtualAssessmentSuccessOpen,
     isTermsAccepted,
     isLoading,
-    virtualAssessment,
     appointment,
     formattedStartDate,
     handleActivityLogModalOpen,

--- a/src/components/appointments/appointment-drawer/hooks.ts
+++ b/src/components/appointments/appointment-drawer/hooks.ts
@@ -14,6 +14,7 @@ type ReturnType = {
   isCompleteModalOpen: boolean;
   isAgreementModalOpen: boolean;
   isActivityLogModalOpen: boolean;
+  isReviewActivityLogModalOpen: boolean;
   isVirtualAssessmentModalOpen: boolean;
   isVirtualAssessmentSuccessOpen: boolean;
   isTermsAccepted: boolean;
@@ -30,6 +31,8 @@ type ReturnType = {
   handleVirtualAssessmentModalClose: () => void;
   handleActivityLogModalOpen: () => void;
   handleActivityLogModalClose: () => void;
+  handleReviewActivityLogModalOpen: () => void;
+  handleReviewActivityLogModalClose: () => void;
   handleVirtualAssessmentSuccessModalOpen: () => void;
   handleVirtualAssessmentSuccessModalClose: () => void;
   setIsTermsAccepted: Dispatch<SetStateAction<boolean>>;
@@ -47,6 +50,7 @@ export function useAppointmentDrawer({
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState<boolean>(false);
   const [isAgreementModalOpen, setIsAgreementModalOpen] = useState<boolean>(false);
   const [isActivityLogModalOpen, setIsActivityLogModalOpen] = useState<boolean>(false);
+  const [isReviewActivityLogModalOpen, setIsReviewActivityLogModalOpen] = useState<boolean>(false);
   const [isVirtualAssessmentModalOpen, setIsVirtualAssessmentModalOpen] = useState<boolean>(false);
   const [isVirtualAssessmentSuccessOpen, setIsVirtualAssessmentSuccessOpen] =
     useState<boolean>(false);
@@ -97,6 +101,14 @@ export function useAppointmentDrawer({
     setIsActivityLogModalOpen(false);
   };
 
+  const handleReviewActivityLogModalOpen = (): void => {
+    setIsReviewActivityLogModalOpen(true);
+    setIsDrawerOpen(false);
+  };
+  const handleReviewActivityLogModalClose = (): void => {
+    setIsReviewActivityLogModalOpen(false);
+  };
+
   const handleVirtualAssessmentModalOpen = (): void => {
     setIsVirtualAssessmentModalOpen(true);
     setIsDrawerOpen(false);
@@ -130,6 +142,7 @@ export function useAppointmentDrawer({
     isCompleteModalOpen,
     isAgreementModalOpen,
     isActivityLogModalOpen,
+    isReviewActivityLogModalOpen,
     isVirtualAssessmentModalOpen,
     isVirtualAssessmentSuccessOpen,
     isTermsAccepted,
@@ -138,6 +151,8 @@ export function useAppointmentDrawer({
     formattedStartDate,
     handleActivityLogModalOpen,
     handleActivityLogModalClose,
+    handleReviewActivityLogModalOpen,
+    handleReviewActivityLogModalClose,
     handleCancelModalOpen,
     handleCancelModalClose,
     handleCompleteModalOpen,

--- a/src/components/appointments/appointment-drawer/review-activity-log-modal/RejectReviewActivityLogModal.tsx
+++ b/src/components/appointments/appointment-drawer/review-activity-log-modal/RejectReviewActivityLogModal.tsx
@@ -1,0 +1,77 @@
+import { Button, FilledInput, FormControl, InputLabel } from '@mui/material';
+
+import Modal from 'src/components/reusable/modal/Modal';
+import { useLocales } from 'src/locales';
+
+import { yupResolver } from '@hookform/resolvers/yup';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { Container, DoubleButtonBox, ErrorMessage } from './styles';
+import {
+  RejectReviewActivityLogModalFormValues,
+  useRejectReviewActivityLogModalSchema,
+} from './validation';
+
+interface IProps {
+  onClose: () => void;
+  isOpen: boolean;
+  onSubmit: (reason?: string) => void;
+}
+
+export default function RejectReviewActivityLogModal({
+  onClose,
+  isOpen,
+  onSubmit,
+}: IProps): JSX.Element {
+  const { translate } = useLocales();
+
+  const rejectReviewActivityLogModalSchema = useRejectReviewActivityLogModalSchema();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty, isValid },
+  } = useForm<RejectReviewActivityLogModalFormValues>({
+    resolver: yupResolver(rejectReviewActivityLogModalSchema),
+    mode: 'onChange',
+  });
+
+  const handleSubmitClick: SubmitHandler<RejectReviewActivityLogModalFormValues> = async (data) => {
+    try {
+      await onSubmit(data.reason);
+    } catch (error) {
+      throw new Error(error);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal
+      onClose={onClose}
+      title={translate('appointments_page.reject')}
+      isActive={isOpen}
+      footerChildren={
+        <Button
+          type="submit"
+          fullWidth
+          disabled={!isDirty || !isValid}
+          variant="contained"
+          color="primary"
+          onClick={handleSubmit(handleSubmitClick)}
+        >
+          {translate('appointments_page.confirm')}
+        </Button>
+      }
+    >
+      <Container>
+        <DoubleButtonBox>
+          <FormControl fullWidth variant="filled">
+            <InputLabel htmlFor="workplace">
+              {translate('appointments_page.rejectReviewActivityLogModal.specifyReason')}
+            </InputLabel>
+            <FilledInput {...register('reason')} error={!!errors.reason} />
+            {errors?.reason && <ErrorMessage>{errors.reason?.message}</ErrorMessage>}
+          </FormControl>
+        </DoubleButtonBox>
+      </Container>
+    </Modal>
+  );
+}

--- a/src/components/appointments/appointment-drawer/review-activity-log-modal/ReviewActivityLogModal.tsx
+++ b/src/components/appointments/appointment-drawer/review-activity-log-modal/ReviewActivityLogModal.tsx
@@ -9,7 +9,14 @@ import { useState } from 'react';
 import { appointmentApi } from 'src/redux/api/appointmentApi';
 import RejectReviewActivityLogModal from './RejectReviewActivityLogModal';
 import { getLatestPendingActivityLog } from './helpers';
-import { Container, DoubleButtonBox, ModalFooter, StyledTask, StyledTaskList } from './styles';
+import {
+  Container,
+  DoubleButtonBox,
+  ModalFooter,
+  StyledTask,
+  StyledTaskList,
+  StyledTitle,
+} from './styles';
 
 interface IProps {
   onClose: () => void;
@@ -92,6 +99,7 @@ export default function ReviewActivityLogModal({
         }
       >
         <Container>
+          <StyledTitle>{translate('appointments_page.completedTasks')}</StyledTitle>
           <DoubleButtonBox>
             <StyledTaskList>
               {tasks.map((task) => (

--- a/src/components/appointments/appointment-drawer/review-activity-log-modal/ReviewActivityLogModal.tsx
+++ b/src/components/appointments/appointment-drawer/review-activity-log-modal/ReviewActivityLogModal.tsx
@@ -1,0 +1,113 @@
+import { Button } from '@mui/material';
+import { useAppDispatch } from 'src/redux/store';
+
+import Modal from 'src/components/reusable/modal/Modal';
+import { useLocales } from 'src/locales';
+import { ActivityLog, ActivityLogStatus, activityLogApi } from 'src/redux/api/activityLogApi';
+
+import { useState } from 'react';
+import { appointmentApi } from 'src/redux/api/appointmentApi';
+import RejectReviewActivityLogModal from './RejectReviewActivityLogModal';
+import { getLatestPendingActivityLog } from './helpers';
+import { Container, DoubleButtonBox, ModalFooter, StyledTask, StyledTaskList } from './styles';
+
+interface IProps {
+  onClose: () => void;
+  isOpen: boolean;
+  activityLog: ActivityLog[];
+}
+
+export default function ReviewActivityLogModal({
+  onClose,
+  isOpen,
+  activityLog,
+}: IProps): JSX.Element | null {
+  const dispatch = useAppDispatch();
+  const { translate } = useLocales();
+
+  const [isRejectModalOpen, setIsRejectModalOpen] = useState<boolean>(false);
+
+  const [updateActivityLog] = activityLogApi.useUpdateActivityLogMutation();
+
+  const pendingActivityLog = getLatestPendingActivityLog(activityLog);
+
+  if (!pendingActivityLog) return null;
+
+  const { id, appointmentId, tasks } = pendingActivityLog;
+
+  const onSubmit = async (reason?: string): Promise<void> => {
+    try {
+      await updateActivityLog({
+        id,
+        status: reason ? ActivityLogStatus.Rejected : ActivityLogStatus.Approved,
+        reason,
+      })
+        .unwrap()
+        .then(() => {
+          dispatch(
+            appointmentApi.util.invalidateTags([{ type: 'Appointments', id: appointmentId }])
+          );
+        });
+    } catch (error) {
+      throw new Error(error);
+    }
+    onClose();
+  };
+
+  const handleRejectClick = (): void => {
+    setIsRejectModalOpen(true);
+  };
+
+  const handleRejectModalClose = (): void => {
+    setIsRejectModalOpen(false);
+  };
+
+  return (
+    <>
+      <Modal
+        onClose={onClose}
+        title={translate('appointments_page.reviewActivityLog')}
+        isActive={isOpen}
+        footerChildren={
+          <ModalFooter>
+            <Button
+              type="submit"
+              fullWidth
+              variant="outlined"
+              color="error"
+              onClick={handleRejectClick}
+            >
+              {translate('appointments_page.reject')}
+            </Button>
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              color="primary"
+              onClick={(): Promise<void> => onSubmit()}
+            >
+              {translate('appointments_page.confirm')}
+            </Button>
+          </ModalFooter>
+        }
+      >
+        <Container>
+          <DoubleButtonBox>
+            <StyledTaskList>
+              {tasks.map((task) => (
+                <StyledTask key={task}>{task}</StyledTask>
+              ))}
+            </StyledTaskList>
+          </DoubleButtonBox>
+        </Container>
+      </Modal>
+      {isRejectModalOpen && (
+        <RejectReviewActivityLogModal
+          isOpen={isRejectModalOpen}
+          onClose={handleRejectModalClose}
+          onSubmit={onSubmit}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/appointments/appointment-drawer/review-activity-log-modal/helpers.ts
+++ b/src/components/appointments/appointment-drawer/review-activity-log-modal/helpers.ts
@@ -1,0 +1,12 @@
+import { ActivityLog, ActivityLogStatus } from 'src/redux/api/activityLogApi';
+
+/**
+ * Retrieves the latest pending activity log from the given array.
+ *
+ * @param {ActivityLog[]} activityLogArray - array of activity logs.
+ * @returns {ActivityLog | undefined} The latest pending activity log, or undefined if not found.
+ */
+export const getLatestPendingActivityLog = (
+  activityLogArray: ActivityLog[]
+): ActivityLog | undefined =>
+  activityLogArray.find((item) => item.status === ActivityLogStatus.Pending);

--- a/src/components/appointments/appointment-drawer/review-activity-log-modal/styles.ts
+++ b/src/components/appointments/appointment-drawer/review-activity-log-modal/styles.ts
@@ -1,0 +1,39 @@
+import { Button, Typography, styled } from '@mui/material';
+import { TYPOGRAPHY } from 'src/theme/fonts';
+import typography from 'src/theme/typography';
+import { Task, TaskList } from '../styles';
+
+export const Container = styled('div')`
+  width: 430px;
+`;
+
+export const DoubleButtonBox = styled('div')`
+  display: flex;
+  gap: 16px;
+`;
+
+export const StyledButton = styled(Button)`
+  border-radius: 4px;
+  width: 100%;
+`;
+
+export const StyledTaskList = styled(TaskList)`
+  width: 100%;
+`;
+
+export const StyledTask = styled(Task)`
+  &:last-child {
+    border: none;
+  }
+`;
+
+export const ModalFooter = styled('div')`
+  gap: 16px;
+  display: flex;
+`;
+
+export const ErrorMessage = styled(Typography)`
+  color: ${({ theme }): string => theme.palette.error.main};
+  font-size: ${TYPOGRAPHY.xss}px;
+  font-weight: ${typography.fontWeightMedium};
+`;

--- a/src/components/appointments/appointment-drawer/review-activity-log-modal/styles.ts
+++ b/src/components/appointments/appointment-drawer/review-activity-log-modal/styles.ts
@@ -1,4 +1,5 @@
 import { Button, Typography, styled } from '@mui/material';
+import { SECONDARY } from 'src/theme/colors';
 import { TYPOGRAPHY } from 'src/theme/fonts';
 import typography from 'src/theme/typography';
 import { Task, TaskList } from '../styles';
@@ -35,5 +36,11 @@ export const ModalFooter = styled('div')`
 export const ErrorMessage = styled(Typography)`
   color: ${({ theme }): string => theme.palette.error.main};
   font-size: ${TYPOGRAPHY.xss}px;
+  font-weight: ${typography.fontWeightMedium};
+`;
+
+export const StyledTitle = styled(Typography)`
+  color: ${SECONDARY.gray_semi_transparent};
+  font-size: ${TYPOGRAPHY.xs}px;
   font-weight: ${typography.fontWeightMedium};
 `;

--- a/src/components/appointments/appointment-drawer/review-activity-log-modal/validation.ts
+++ b/src/components/appointments/appointment-drawer/review-activity-log-modal/validation.ts
@@ -1,0 +1,29 @@
+import { MAX_CHARACTERS_LENGTH } from 'src/constants';
+import { useLocales } from 'src/locales';
+import { AnyObject, ObjectSchema, object, string } from 'yup';
+
+export type RejectReviewActivityLogModalFormValues = {
+  reason: string;
+};
+
+export const useRejectReviewActivityLogModalSchema = (): ObjectSchema<
+  RejectReviewActivityLogModalFormValues,
+  AnyObject,
+  {
+    reason: undefined;
+  },
+  ''
+> => {
+  const { translate } = useLocales();
+
+  return object({
+    reason: string()
+      .trim()
+      .required(translate('appointments_page.rejectReviewActivityLogModal.reasonRequired'))
+      .min(1, translate('appointments_page.rejectReviewActivityLogModal.reasonRequired'))
+      .max(
+        MAX_CHARACTERS_LENGTH,
+        translate('appointments_page.rejectReviewActivityLogModal.reasonMaxLength')
+      ),
+  });
+};

--- a/src/components/appointments/appointments-list/AppointmentsList.tsx
+++ b/src/components/appointments/appointments-list/AppointmentsList.tsx
@@ -1,13 +1,13 @@
-import { useState } from 'react';
 import { IconButton } from '@mui/material';
+import { useState } from 'react';
 
-import { useTypedSelector } from 'src/redux/store';
 import RightAction from 'src/assets/icons/RightAction';
-import AppointmentStatus from 'src/components/appointments/appointment-status/AppointmentStatus';
 import AppointmentDrawer from 'src/components/appointments/appointment-drawer/AppointmentDrawer';
-import CaregiverDrawer from 'src/components/reusable/drawer/caregiver-drawer/CaregiverDrawer';
+import AppointmentStatus from 'src/components/appointments/appointment-status/AppointmentStatus';
 import { AppointmentsProps } from 'src/components/appointments/types';
+import CaregiverDrawer from 'src/components/reusable/drawer/caregiver-drawer/CaregiverDrawer';
 import { APPOINTMENT_STATUS } from 'src/constants';
+import { useTypedSelector } from 'src/redux/store';
 
 import { Item, RejectedTitle, TextContainer, Title } from './styles';
 
@@ -70,11 +70,13 @@ export default function AppointmentsList({ appointments }: AppointmentsProps): J
           selectedAppointmentId={selectedAppointmentId}
         />
       )}
-      <CaregiverDrawer
-        open={isCaregiverDrawerOpen}
-        onClose={handleCaregiverDrawerClose}
-        caregiverId={caregiverId}
-      />
+      {isCaregiverDrawerOpen && caregiverId && (
+        <CaregiverDrawer
+          open={isCaregiverDrawerOpen}
+          onClose={handleCaregiverDrawerClose}
+          caregiverId={caregiverId}
+        />
+      )}
     </>
   );
 }

--- a/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
+++ b/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
@@ -7,6 +7,9 @@ import jwt_decode from 'jwt-decode';
 import { useMemo, useState } from 'react';
 
 import { DRAWER_DATE_FORMAT } from 'src/components/appointments/constants';
+import VirtualAssessmentSuccess from 'src/components/appointments/request-sent-modal/VirtualAssessmentSuccess';
+import VirtualAssessmentModal from 'src/components/appointments/virtual-assessment-modal/VirtualAssessmentModal';
+import { AssessmentPurpose } from 'src/components/appointments/virtual-assessment-modal/enums';
 import { FilledButton } from 'src/components/reusable';
 import FlowHeader from 'src/components/reusable/header/FlowHeader';
 import { USER_ROLE, VIRTUAL_ASSESSMENT_STATUS } from 'src/constants';
@@ -14,11 +17,7 @@ import { useLocales } from 'src/locales';
 import { virtualAssessmentApi } from 'src/redux/api/virtualAssessmentApi';
 import { useTypedSelector } from 'src/redux/store';
 import { setCustomTime } from 'src/utils/defineCustomTime';
-import VirtualAssessmentSuccess from 'src/components/appointments/request-sent-modal/VirtualAssessmentSuccess';
-import VirtualAssessmentModal from 'src/components/appointments/virtual-assessment-modal/VirtualAssessmentModal';
-import { AssessmentPurpose } from 'src/components/appointments/virtual-assessment-modal/enums';
 
-import { VirtualAssessmentRequestModalProps } from './types';
 import {
   AppointmentModal,
   AppointmentModalBlock,
@@ -31,6 +30,7 @@ import {
   NameParagraph,
   NotificationMessage,
 } from './styles';
+import { VirtualAssessmentRequestModalProps } from './types';
 
 const decodeToken = (tokenToDecode: string): string => {
   const decoded: { id: string } = jwt_decode(tokenToDecode);
@@ -44,7 +44,6 @@ const VirtualAssessmentRequestModal = ({
   switchModalVisibility,
   openDrawer,
   closeDrawer,
-  virtualAssessment,
 }: VirtualAssessmentRequestModalProps): JSX.Element => {
   const { translate } = useLocales();
 
@@ -159,7 +158,7 @@ const VirtualAssessmentRequestModal = ({
               <NotificationsNoneOutlinedIcon color="primary" />
               {translate('request_appointment.notify_message')}
             </NotificationMessage>
-            {virtualAssessment?.status === VIRTUAL_ASSESSMENT_STATUS.Proposed &&
+            {appointment.virtualAssessment?.status === VIRTUAL_ASSESSMENT_STATUS.Proposed &&
               !appointment.virtualAssessment?.wasRescheduled && (
                 <InlineBlock>
                   <Button
@@ -181,7 +180,7 @@ const VirtualAssessmentRequestModal = ({
                   </FilledButton>
                 </InlineBlock>
               )}
-            {virtualAssessment?.status === VIRTUAL_ASSESSMENT_STATUS.Proposed &&
+            {appointment.virtualAssessment?.status === VIRTUAL_ASSESSMENT_STATUS.Proposed &&
               appointment.virtualAssessment?.wasRescheduled && (
                 <InlineBlock>
                   <Button

--- a/src/components/virtual-assessment-request/types.ts
+++ b/src/components/virtual-assessment-request/types.ts
@@ -1,11 +1,9 @@
 import { DetailedAppointment } from 'src/redux/api/appointmentApi';
-import { VirtualAssessment } from 'src/redux/api/virtualAssessmentApi';
 
 export type VirtualAssessmentRequestModalProps = {
   appointment: DetailedAppointment;
   isOpen: boolean;
   switchModalVisibility: () => void;
   openDrawer: () => void;
-  virtualAssessment: VirtualAssessment | undefined;
   closeDrawer: () => void;
 };

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -551,8 +551,10 @@ const en = {
     signed: 'Signed',
     agreementSignedDate: 'Date: ',
     activityLog: 'Activity Log',
-    reviewed: 'Reviewed',
+    reviewActivityLog: 'Review Activity Log',
     confirm: 'Confirm',
+    reject: 'Reject',
+    reviewed: 'Reviewed',
     filled: 'Filled',
     modal_subtitle: 'Are you sure you would like to cancel the appointment?',
     complete_modal_title: 'Complete appointment',
@@ -573,6 +575,11 @@ const en = {
     },
     activityLogModal: {
       tasksRequired: 'At least one task is required',
+    },
+    rejectReviewActivityLogModal: {
+      specifyReason: 'Specify reason',
+      reasonRequired: 'Please specify a reason',
+      reasonMaxLength: `Reason must be at most ${MAX_CHARACTERS_LENGTH} characters`,
     },
     drawer: {
       agreement: 'Agreement',
@@ -699,11 +706,6 @@ const en = {
     },
     personalInfoModal: { title: 'Edit Personal Information', saveButton: 'Save' },
     addressModal: { title: 'Edit Address' },
-  },
-  getHelpModal: {
-    title: 'Get Help',
-    subtitle: 'Need assistance? We`re here to help!',
-    text: 'If you have any questions, concerns, or issues, you can reach out to our dedicated support team via email',
   },
 };
 

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -6,13 +6,13 @@ import {
   MIN_APPOINTMENT_NAME_LENGTH,
 } from 'src/components/create-appointment/constants';
 
-import { CONFIRM_NOTE_MAX_LENGTH } from 'src/components/confirm-appointment/constants';
-import { MAX_CHARACTERS_LENGTH } from 'src/constants';
 import {
   MAX_ASSESSMENT_HOURS_DURATION,
   MAX_REASON_LENGTH,
   MIN_REASON_LENGTH,
 } from 'src/components/appointments/virtual-assessment-modal/constants';
+import { CONFIRM_NOTE_MAX_LENGTH } from 'src/components/confirm-appointment/constants';
+import { MAX_CHARACTERS_LENGTH } from 'src/constants';
 
 const en = {
   app_title: 'CtrlChamps',
@@ -706,6 +706,11 @@ const en = {
     },
     personalInfoModal: { title: 'Edit Personal Information', saveButton: 'Save' },
     addressModal: { title: 'Edit Address' },
+  },
+  getHelpModal: {
+    title: 'Get Help',
+    subtitle: 'Need assistance? We`re here to help!',
+    text: 'If you have any questions, concerns, or issues, you can reach out to our dedicated support team via email',
   },
 };
 

--- a/src/redux/api/activityLogApi.ts
+++ b/src/redux/api/activityLogApi.ts
@@ -9,10 +9,15 @@ export enum ActivityLogStatus {
 }
 
 export interface ActivityLog {
+  id: string;
   appointmentId: string;
   status: ActivityLogStatus;
   tasks: string[];
   createdAt: string;
+}
+
+interface UpdateActivityLogPayload extends Pick<ActivityLog, 'id' | 'status'> {
+  reason?: string;
 }
 
 export const activityLogApi = createApi({
@@ -31,11 +36,18 @@ export const activityLogApi = createApi({
     },
   }),
   endpoints: (builder) => ({
-    createActivityLog: builder.mutation<void, Omit<ActivityLog, 'createdAt'>>({
+    createActivityLog: builder.mutation<void, Omit<ActivityLog, 'createdAt' | 'id'>>({
       query: (body) => ({
         url: route.activityLog,
         method: 'POST',
         body,
+      }),
+    }),
+    updateActivityLog: builder.mutation<void, UpdateActivityLogPayload>({
+      query: ({ id, ...activityLog }) => ({
+        url: `${route.activityLog}/${id}`,
+        method: 'PATCH',
+        body: activityLog,
       }),
     }),
   }),


### PR DESCRIPTION
## Describe your changes

- Added review activity log modal.
- Added reject review activity log modal.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-151?atlOrigin=eyJpIjoiYmZkODRiM2ZkM2JlNDg0ZjlkMWJjNWRlNDdkMzcyMmMiLCJwIjoiaiJ9)

![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/92c3ff2b-3f3c-4c14-a9e4-bba659e52287)
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/62f41139-6f80-4070-8458-36362a131ea3)
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/d72240a0-221e-4d7c-94e7-a2d8e85ef52c)
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/7a5cac7b-2a7c-4c9e-8bb8-60acc6112dfe)
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/209fee1f-a327-41ea-89a9-cd87e798fe51)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.


