### PR TITLE
fix: change logic to open caregiver drawer on confirm appointment step

### DIFF
--- a/src/components/confirm-appointment/ConfirmAppointment.tsx
+++ b/src/components/confirm-appointment/ConfirmAppointment.tsx
@@ -12,6 +12,8 @@ import { APPOINTMENT_STATUS } from 'src/constants';
 import { Appointment } from 'src/components/create-appointment/enums';
 import { ROUTES } from 'src/routes';
 import AppointmentBtn from 'src/components/reusable/appointment-btn/AppointmentBtn';
+import CreateAppointmentFourthDrawer from 'src/components/create-appointment-fourth/CreateAppointmentFourthDrawer';
+
 import {
   Container,
   Header,
@@ -37,18 +39,18 @@ export default function ConfirmAppointment({ onBack }: { onBack: () => void }): 
   const [tasks, setTasks] = useState<string[]>([]);
   const [details, setDetails] = useState<string>('');
   const [isModalActive, setIsModalActive] = useState<boolean>(false);
+  const [isCaregiverDrawerOpen, setIsCaregiverDrawerOpen] = useState<boolean>(false);
   const [createAppointment] = useCreateAppointmentMutation();
 
   const onOpenModal = (): void => setIsModalActive(true);
   const onCloseModal = (): void => setIsModalActive(false);
 
+  const openDrawer = (): void => setIsCaregiverDrawerOpen(true);
+  const closeDrawer = (): void => setIsCaregiverDrawerOpen(false);
+
   const deleteTask = (idx: number): void => {
     const filtered = tasks.filter((el, i) => i !== idx);
     setTasks(filtered);
-  };
-
-  const goToProfileStep = (): void => {
-    onBack();
   };
 
   const confirmAppointment = async (): Promise<void> => {
@@ -93,7 +95,7 @@ export default function ConfirmAppointment({ onBack }: { onBack: () => void }): 
         <InnerContainer>
           <Header>
             <Typography>{translate('confirm_appointment.caregiver')}</Typography>
-            <LinkToProfile onClick={goToProfileStep}>
+            <LinkToProfile onClick={openDrawer}>
               <Avatar />
               <Name>{`${caregiver?.firstName} ${caregiver?.lastName}`}</Name>
               <ArrowForward />
@@ -129,6 +131,13 @@ export default function ConfirmAppointment({ onBack }: { onBack: () => void }): 
           />
         </InnerContainer>
       </Container>
+      {caregiver && (
+        <CreateAppointmentFourthDrawer
+          open={isCaregiverDrawerOpen}
+          onClose={closeDrawer}
+          selectedCaregiverId={caregiver.id}
+        />
+      )}
     </PageBackground>
   );
 }

--- a/src/components/create-appointment-fourth/CreateAppointmentFourthDrawer.tsx
+++ b/src/components/create-appointment-fourth/CreateAppointmentFourthDrawer.tsx
@@ -10,8 +10,8 @@ interface CreateAppointmentFourthDrawerProps {
   open: boolean;
   onClose: () => void;
   selectedCaregiverId: string;
-  onNext: () => void;
-  onBack: () => void;
+  onNext?: () => void;
+  onBack?: () => void;
 }
 
 export default function CreateAppointmentFourthDrawer({
@@ -32,19 +32,21 @@ export default function CreateAppointmentFourthDrawer({
 
   const handleBookClick = (): void => {
     dispatch(setSelectedCaregiver(selectedCaregiver));
-    onNext();
+    if (onNext) onNext();
   };
 
   return (
     <CaregiverDrawer
       caregiverId={selectedCaregiverId}
       footer={
-        <AppointmentBtn
-          nextText={translate('createAppointmentFourth.bookAppointment')}
-          backText={translate('profileQualification.back')}
-          onClick={handleBookClick}
-          onBack={onBack}
-        />
+        onNext && (
+          <AppointmentBtn
+            nextText={translate('createAppointmentFourth.bookAppointment')}
+            backText={translate('profileQualification.back')}
+            onClick={handleBookClick}
+            onBack={onBack}
+          />
+        )
       }
       onClose={onClose}
       open={open}


### PR DESCRIPTION
## Describe your changes

- I changed logic so that the user could view caregiver's profile on 'confirm appointment' step instead of going back to 'find caregiver' step.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-259)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.


