### PR TITLE
fix: fix tab arrows and styling

### DIFF
--- a/src/components/reusable/drawer/caregiver-drawer/CaregiverDrawer.tsx
+++ b/src/components/reusable/drawer/caregiver-drawer/CaregiverDrawer.tsx
@@ -95,8 +95,8 @@ export default function CaregiverDrawer({
       <TabContext value={selectedTab}>
         <StyledTabs
           value={selectedTab}
+          scrollButtons="auto"
           onChange={handleTabClick}
-          scrollButtons={false}
           textColor="secondary"
           indicatorColor="secondary"
         >

--- a/src/theme/overrides/Tabs.ts
+++ b/src/theme/overrides/Tabs.ts
@@ -25,17 +25,15 @@ export default function Tabs(theme: Theme) {
       },
       styleOverrides: {
         root: ({ ownerState }: { ownerState: TabProps }) => ({
-          padding: 0,
           opacity: 1,
+          minWidth: 'auto',
           fontWeight: theme.typography.fontWeightMedium,
-          '&:not(:last-of-type)': {
-            padding: theme.spacing(2),
+          padding: theme.spacing(2),
+          '&.Mui-selected': {
+            color: theme.palette.secondary.main,
           },
           '&:not(.Mui-selected)': {
             color: theme.palette.text.secondary,
-          },
-          '&.Mui-selected': {
-            color: theme.palette.secondary.main,
           },
           ...((ownerState.iconPosition === 'start' || ownerState.iconPosition === 'end') && {
             minHeight: 48,


### PR DESCRIPTION
## Describe your changes

- Fixed caregiver drawer to let user access services tab via arrows

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-272?atlOrigin=eyJpIjoiM2IwNDNhNDM4YjlkNGEyNWEzZjVkY2M2NzhkZGZmYmQiLCJwIjoiaiJ9)


![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/ec4ac3d0-a1b9-462a-8f48-01c478a23d8a)
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/106f3fa6-b78a-4d3c-9f82-a6ce934eccf2)

### **General**

- [x] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
