### PR TITLE
fix: reset all appointment info after it has been created

### DIFF
--- a/src/components/confirm-appointment/ConfirmAppointment.tsx
+++ b/src/components/confirm-appointment/ConfirmAppointment.tsx
@@ -6,7 +6,7 @@ import { Avatar } from '@mui/material';
 import ArrowForward from 'src/assets/icons/ArrowForward';
 import TasksList from 'src/components/confirm-appointment/TasksList';
 import { useLocales } from 'src/locales';
-import { useTypedSelector } from 'src/redux/store';
+import { useAppDispatch, useTypedSelector } from 'src/redux/store';
 import { useCreateAppointmentMutation } from 'src/redux/api/appointmentApi';
 import { APPOINTMENT_STATUS } from 'src/constants';
 import { Appointment } from 'src/components/create-appointment/enums';
@@ -14,6 +14,8 @@ import { ROUTES } from 'src/routes';
 import AppointmentBtn from 'src/components/reusable/appointment-btn/AppointmentBtn';
 import CreateAppointmentFourthDrawer from 'src/components/create-appointment-fourth/CreateAppointmentFourthDrawer';
 
+import { cancelAppointment as resetAppointmentInfo } from 'src/redux/slices/appointmentSlice';
+import { resetAllInfo } from 'src/redux/slices/healthQuestionnaireSlice';
 import {
   Container,
   Header,
@@ -31,6 +33,7 @@ import { CONFIRM_NOTE_MAX_LENGTH } from './constants';
 export default function ConfirmAppointment({ onBack }: { onBack: () => void }): JSX.Element {
   const { translate } = useLocales();
   const router = useRouter();
+  const dispatch = useAppDispatch();
   const caregiver = useTypedSelector((state) => state.caregiver.selectedCaregiver);
   const appointment = useTypedSelector((state) => state.appointment);
   const location = useTypedSelector((state) => state.location);
@@ -40,7 +43,7 @@ export default function ConfirmAppointment({ onBack }: { onBack: () => void }): 
   const [details, setDetails] = useState<string>('');
   const [isModalActive, setIsModalActive] = useState<boolean>(false);
   const [isCaregiverDrawerOpen, setIsCaregiverDrawerOpen] = useState<boolean>(false);
-  const [createAppointment] = useCreateAppointmentMutation();
+  const [createAppointment, { isLoading }] = useCreateAppointmentMutation();
 
   const onOpenModal = (): void => setIsModalActive(true);
   const onCloseModal = (): void => setIsModalActive(false);
@@ -84,6 +87,8 @@ export default function ConfirmAppointment({ onBack }: { onBack: () => void }): 
         seekerActivities: healthQuestionnaire.selectedActivities,
       }).unwrap();
       router.push(ROUTES.home);
+      dispatch(resetAppointmentInfo());
+      dispatch(resetAllInfo());
     } catch (err) {
       throw new Error(err);
     }
@@ -125,7 +130,7 @@ export default function ConfirmAppointment({ onBack }: { onBack: () => void }): 
           <AppointmentBtn
             nextText={translate('confirm_appointment.confirm')}
             backText={translate('profileQualification.back')}
-            disabled={!tasks.length || details.length > CONFIRM_NOTE_MAX_LENGTH}
+            disabled={!tasks.length || details.length > CONFIRM_NOTE_MAX_LENGTH || isLoading}
             onClick={confirmAppointment}
             onBack={onBack}
           />

--- a/src/redux/slices/healthQuestionnaireSlice.ts
+++ b/src/redux/slices/healthQuestionnaireSlice.ts
@@ -48,10 +48,11 @@ const healthQuestionnaireSlice = createSlice({
       const { step, note } = action.payload;
       state.notes[step] = note;
     },
+    resetAllInfo: () => initialState,
   },
 });
 
-export const { selectDiagnosis, selectActivity, selectEnvChallenges, saveNote } =
+export const { selectDiagnosis, selectActivity, selectEnvChallenges, saveNote, resetAllInfo } =
   healthQuestionnaireSlice.actions;
 
 export default healthQuestionnaireSlice.reducer;


### PR DESCRIPTION
## Describe your changes

- I added logic of resetting all appointment info after it has been created + the button should be disabled if there is ongoing request.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-304)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.

