### PR TITLE
fix: Complete profile 3,5

### DIFF
--- a/src/components/complete-profile-fifth/CompleteProfileFifth.tsx
+++ b/src/components/complete-profile-fifth/CompleteProfileFifth.tsx
@@ -42,7 +42,7 @@ function CompleteProfileFifth({ onNext, onBack }: IProps): JSX.Element {
   const {
     control,
     handleSubmit,
-    formState: { isDirty, errors, isValid },
+    formState: { errors, isValid },
   } = useForm<CompleteProfileFifthValues>({
     mode: 'onBlur',
     resolver: yupResolver(completeProfileFifthSchema),
@@ -116,7 +116,7 @@ function CompleteProfileFifth({ onNext, onBack }: IProps): JSX.Element {
         <ProfileBtn
           nextText={translate('btn_next')}
           backText={translate('profileQualification.back')}
-          disabled={!isDirty || !isValid}
+          disabled={!isValid}
           onBack={onBack}
         />
       </StyledForm>

--- a/src/components/complete-profile-third/CompleteProfileThird.tsx
+++ b/src/components/complete-profile-third/CompleteProfileThird.tsx
@@ -23,7 +23,7 @@ function CompleteProfileThird({ onNext, onBack }: IProps): JSX.Element {
   const {
     control,
     handleSubmit,
-    formState: { isDirty, isValid },
+    formState: { isValid },
   } = useForm<CompleteProfileThirdValues>({
     mode: 'onBlur',
     resolver: yupResolver(servicesSchema),
@@ -143,7 +143,7 @@ function CompleteProfileThird({ onNext, onBack }: IProps): JSX.Element {
         <ProfileBtn
           nextText={translate('btn_next')}
           backText={translate('profileQualification.back')}
-          disabled={!isDirty || !isValid}
+          disabled={!isValid}
           onBack={onBack}
         />
       </StyledForm>


### PR DESCRIPTION
## Describe your changes

- removed IsDirty from Next button in Services and Rate. Now user can click Next even if he didn't change services or rate

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-306)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.