### PR TITLE
fix: change default accordion icon

### DIFF
--- a/src/components/faq-accordion/FaqAccordion.tsx
+++ b/src/components/faq-accordion/FaqAccordion.tsx
@@ -1,4 +1,4 @@
-import { ExpandLess } from '@mui/icons-material';
+import { ExpandMore } from '@mui/icons-material';
 import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material';
 import { SyntheticEvent, useMemo, useState } from 'react';
 import { FIRST_ELEMENT } from 'src/components/complete-profile-fourth/constants';
@@ -38,7 +38,7 @@ export default function FaqAccordion(): JSX.Element {
         >
           <AccordionSummary
             aria-controls={`${question.title}-content`}
-            expandIcon={<ExpandLess />}
+            expandIcon={<ExpandMore />}
             id={`${question.title}-header`}
           >
             <Typography>{question.title}</Typography>


### PR DESCRIPTION
## Describe your changes

- Changed default faq accordion icon
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/61708790/4bb7f131-7e12-4ae1-b922-3af16c94767d)

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-193?atlOrigin=eyJpIjoiYjRiYWEyMjc4NzBjNDAxYTllN2EwYmRmZmE4ZTczNTQiLCJwIjoiaiJ9)

### **General**

- [x] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.

