### PR TITLE
fix: update avatar button text

### DIFF
--- a/src/components/account-details/AccountDetails.tsx
+++ b/src/components/account-details/AccountDetails.tsx
@@ -1,7 +1,7 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import PhotoCameraOutlinedIcon from '@mui/icons-material/PhotoCameraOutlined';
-import { Button, FormControl, FormControlLabel, Switch } from '@mui/material';
+import { Button, FormControl, FormControlLabel, Switch, IconButton } from '@mui/material';
 import { ChangeEvent, useState } from 'react';
 import { Controller, ControllerRenderProps, useForm } from 'react-hook-form';
 import { ReactElement } from 'react-markdown/lib/react-markdown';
@@ -31,7 +31,6 @@ import {
   StyledAvatar,
   Subtitle,
   Title,
-  TrashButton,
   Value,
   VisuallyHiddenInput,
   ButtonContainer,
@@ -140,9 +139,9 @@ export default function AccountDetails({ user }: IProps): JSX.Element | null {
                     </Button>
                     {user.avatar ||
                       (avatar && (
-                        <TrashButton onClick={onDeleteAvatar}>
+                        <IconButton onClick={onDeleteAvatar}>
                           <DeleteOutlineIcon color="primary" />
-                        </TrashButton>
+                        </IconButton>
                       ))}
                   </ButtonContainer>
                 )}

--- a/src/components/account-details/AccountDetails.tsx
+++ b/src/components/account-details/AccountDetails.tsx
@@ -34,6 +34,7 @@ import {
   TrashButton,
   Value,
   VisuallyHiddenInput,
+  ButtonContainer,
 } from './styles';
 import { AvatarValues } from './types';
 import UpdatePassword from './update-password-form/UpdatePassword';
@@ -114,12 +115,7 @@ export default function AccountDetails({ user }: IProps): JSX.Element | null {
 
         <AvatarContainer>
           {user.avatar || avatar ? (
-            <>
-              <StyledAvatar src={avatarURL} alt="avatar" />
-              <TrashButton onClick={onDeleteAvatar}>
-                <DeleteOutlineIcon color="primary" />
-              </TrashButton>
-            </>
+            <StyledAvatar src={avatarURL} alt="avatar" />
           ) : (
             <AvatarIconContainer>
               <PhotoCameraOutlinedIcon color="primary" sx={{ fontSize: TYPOGRAPHY.xl }} />
@@ -131,16 +127,24 @@ export default function AccountDetails({ user }: IProps): JSX.Element | null {
                 name="avatar"
                 control={control}
                 render={({ field }): ReactElement => (
-                  <Button component="label">
-                    {user.avatar || avatar
-                      ? translate('accountDetails.updateAvatar')
-                      : translate('accountDetails.avatarText')}
-                    <VisuallyHiddenInput
-                      type="file"
-                      accept="image/png, image/jpeg, image/heic"
-                      onChange={(e): Promise<void> => onFileChange(e, field)}
-                    />
-                  </Button>
+                  <ButtonContainer>
+                    <Button component="label">
+                      {user.avatar || avatar
+                        ? translate('accountDetails.updateAvatar')
+                        : translate('accountDetails.avatarText')}
+                      <VisuallyHiddenInput
+                        type="file"
+                        accept="image/png, image/jpeg, image/heic"
+                        onChange={(e): Promise<void> => onFileChange(e, field)}
+                      />
+                    </Button>
+                    {user.avatar ||
+                      (avatar && (
+                        <TrashButton onClick={onDeleteAvatar}>
+                          <DeleteOutlineIcon color="primary" />
+                        </TrashButton>
+                      ))}
+                  </ButtonContainer>
                 )}
               />
             </FormControl>

--- a/src/components/account-details/AccountDetails.tsx
+++ b/src/components/account-details/AccountDetails.tsx
@@ -132,7 +132,9 @@ export default function AccountDetails({ user }: IProps): JSX.Element | null {
                 control={control}
                 render={({ field }): ReactElement => (
                   <Button component="label">
-                    {translate('accountDetails.avatarText')}
+                    {user.avatar || avatar
+                      ? translate('accountDetails.updateAvatar')
+                      : translate('accountDetails.avatarText')}
                     <VisuallyHiddenInput
                       type="file"
                       accept="image/png, image/jpeg, image/heic"

--- a/src/components/account-details/styles.ts
+++ b/src/components/account-details/styles.ts
@@ -125,8 +125,11 @@ export const EditButton = styled(IconButton)`
   right: 8px;
 `;
 
+export const ButtonContainer = styled('div')`
+display: flex;
+`
 export const TrashButton = styled(IconButton)`
-  position: absolute;
+  /* position: absolute;
   right: 8px;
-  top: 0;
+  top: 0; */
 `;

--- a/src/components/account-details/styles.ts
+++ b/src/components/account-details/styles.ts
@@ -128,8 +128,3 @@ export const EditButton = styled(IconButton)`
 export const ButtonContainer = styled('div')`
 display: flex;
 `
-export const TrashButton = styled(IconButton)`
-  /* position: absolute;
-  right: 8px;
-  top: 0; */
-`;

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -695,6 +695,7 @@ const en = {
   accountDetails: {
     title: 'Account Details',
     avatarText: 'Upload Photo',
+    updateAvatar: 'Update Photo',
     personalInfo: 'Personal Information',
     address: 'Address',
     password: 'Password',


### PR DESCRIPTION
## Describe your changes

- updated button text. If there is avatar - 'Update photo', if not - 'Upload photo'
- moved trash button.

<img width="405" alt="Снимок экрана 2024-01-04 135422" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/b08e041e-9c41-47f1-8071-fddaaca0f68b">
<img width="402" alt="Снимок экрана 2024-01-04 135426" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/aa395b6b-df90-4f05-a343-f2dc100e0e15">


## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-316)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.