### PR TITLE
fix: updated button's styles in appointment request

### DIFF
--- a/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
+++ b/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
@@ -56,6 +56,7 @@ import {
   DateText,
   DisabledText,
   DoubleButtonBox,
+  AcceptRejectButtonsBox,
   DrawerAvatar,
   DrawerBody,
   ModalFooter,
@@ -173,16 +174,22 @@ export default function AppointmentDrawer({
 
   const DRAWER_FOOTERS = {
     [APPOINTMENT_STATUS.Pending]: (
-      <DoubleButtonBox>
-        {role === USER_ROLE.Caregiver && (
-          <StyledButton type="button" variant="contained" onClick={handleAcceptAppointment}>
-            {translate('appointments_page.accept_button')}
-          </StyledButton>
+      <>
+        {role === USER_ROLE.Caregiver ? (
+          <AcceptRejectButtonsBox>
+            <StyledButton type="button" variant="contained" onClick={handleAcceptAppointment}>
+              {translate('appointments_page.accept')}
+            </StyledButton>
+            <CancelBtn type="button" variant="outlined" onClick={handleCancelModalOpen}>
+              {translate('appointments_page.reject')}
+            </CancelBtn>
+          </AcceptRejectButtonsBox>
+        ) : (
+          <CancelBtn type="button" variant="outlined" onClick={handleCancelModalOpen}>
+            {translate('appointments_page.cancel_button')}
+          </CancelBtn>
         )}
-        <CancelBtn type="button" variant="outlined" onClick={handleCancelModalOpen}>
-          {translate('appointments_page.cancel_button')}
-        </CancelBtn>
-      </DoubleButtonBox>
+      </>
     ),
     [APPOINTMENT_STATUS.Accepted]: (
       <>

--- a/src/components/appointments/appointment-drawer/styles.ts
+++ b/src/components/appointments/appointment-drawer/styles.ts
@@ -108,6 +108,12 @@ export const DoubleButtonBox = styled('div')`
   gap: 16px;
 `;
 
+export const AcceptRejectButtonsBox = styled('div')`
+  display: flex;
+  width: 100%;
+  gap: 16px;
+`;
+
 export const StyledLabel = styled('p')`
   color: ${PRIMARY.black};
   font-size: ${TYPOGRAPHY.base}px;

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -563,6 +563,7 @@ const en = {
     activityLog: 'Activity Log',
     reviewActivityLog: 'Review Activity Log',
     confirm: 'Confirm',
+    accept: 'Accept',
     reject: 'Reject',
     reviewed: 'Reviewed',
     filled: 'Filled',


### PR DESCRIPTION
## Describe your changes

- updated styles of buttons for appointments with status 'Pending confirmation'

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-313)

for Caregiver:
<img width="556" alt="Снимок экрана 2024-01-04 141148" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/4c596fb1-f5f1-4dd6-97c5-76502f5713da">

for Client:
<img width="586" alt="Снимок экрана 2024-01-04 141705" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/6f6dd166-a5a2-4b94-a3ef-f49ae161c7c4">

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
