### PR TITLE
fix: fix one-time appointment logic

### DIFF
--- a/src/components/create-appointment/OneTimeAppointment.tsx
+++ b/src/components/create-appointment/OneTimeAppointment.tsx
@@ -63,16 +63,12 @@ export default function OneTimeAppointment({ onNext, onBack }: Props): JSX.Eleme
       setIdenticalTime(false);
     }
 
-    checkTimeValidity(startTime > endTime);
-  }, [startTime, endTime]);
-
-  const checkTimeValidity = (condition: boolean): void => {
-    if (condition) {
+    if (startTime > endTime) {
       setInvalidTime(true);
     } else {
       setInvalidTime(false);
     }
-  };
+  }, [startTime, endTime]);
 
   const chooseDate = (value: Date | null): void => setDate(value);
 

--- a/src/components/create-appointment/OneTimeAppointment.tsx
+++ b/src/components/create-appointment/OneTimeAppointment.tsx
@@ -31,6 +31,8 @@ export default function OneTimeAppointment({ onNext, onBack }: Props): JSX.Eleme
   const [date, setDate] = useState<Date | null>(oneTimeDate.startTime);
   const [startTime, setStartTime] = useState<string>('');
   const [endTime, setEndTime] = useState<string>('');
+  const [identicalTime, setIdenticalTime] = useState<boolean>(false);
+  const [invalidTime, setInvalidTime] = useState<boolean>(false);
 
   const { hours, minutes, isDurationSet, minValidDuration } = useShowDuration(startTime, endTime);
   const { chooseStartTime, chooseEndTime } = useChooseTime(
@@ -51,6 +53,26 @@ export default function OneTimeAppointment({ onNext, onBack }: Props): JSX.Eleme
       setEndTime(endDateTime);
     }
   }, [oneTimeDate.startTime, oneTimeDate.endTime]);
+
+  useEffect(() => {
+    if (!startTime || !endTime) return;
+
+    if (startTime === endTime) {
+      setIdenticalTime(true);
+    } else {
+      setIdenticalTime(false);
+    }
+
+    checkTimeValidity(startTime > endTime);
+  }, [startTime, endTime]);
+
+  const checkTimeValidity = (condition: boolean): void => {
+    if (condition) {
+      setInvalidTime(true);
+    } else {
+      setInvalidTime(false);
+    }
+  };
 
   const chooseDate = (value: Date | null): void => setDate(value);
 
@@ -78,14 +100,19 @@ export default function OneTimeAppointment({ onNext, onBack }: Props): JSX.Eleme
             chooseEndTime={chooseEndTime}
             chooseDate={chooseDate}
           />
-
-          {startTime && endTime && isDurationSet && !minValidDuration && (
+          {invalidTime && (
+            <ErrorText>{translate('create_appointment.errors.invalid_time')}</ErrorText>
+          )}
+          {identicalTime && (
+            <ErrorText>{translate('create_appointment.errors.identical_time')}</ErrorText>
+          )}
+          {startTime && endTime && startTime !== endTime && isDurationSet && !minValidDuration && (
             <ErrorText>{translate('create_appointment.errors.min_appointment_duration')}</ErrorText>
           )}
           {date && isBefore(date, CURRENT_DAY) && !isSameDay(date, CURRENT_DAY) && (
             <ErrorText>{translate('create_appointment.errors.invalid_date')}</ErrorText>
           )}
-          {startTime && endTime && date && minValidDuration && (
+          {startTime && endTime && date && minValidDuration && !identicalTime && !invalidTime && (
             <AppointmentDuration>
               <OneTimeIcon />
               {minutes > 0
@@ -108,6 +135,8 @@ export default function OneTimeAppointment({ onNext, onBack }: Props): JSX.Eleme
             !startTime ||
             !endTime ||
             !minValidDuration ||
+            invalidTime ||
+            identicalTime ||
             (isBefore(date, CURRENT_DAY) && !isSameDay(date, CURRENT_DAY))
           }
           onClick={goNext}

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -344,6 +344,9 @@ const en = {
       min_type_char: `Appointment name should contain more than ${MIN_APPOINTMENT_NAME_LENGTH} characters`,
       max_type_char: `You cannot enter more than ${MAX_APPOINTMENT_NAME_LENGTH} characters`,
       min_appointment_duration: `An appointment should last for at least ${MIN_APPOINTMENT_HOUR_DURATION} hour.`,
+      invalid_time:
+        'Appointment cannot be ended before the start. Please choose another value in End Time field.',
+      identical_time: 'You cannot choose identical time',
       invalid_date: 'Please select current date or a date in the future.',
       invalid_start_date:
         'The selected start date has already passed. Please choose a future date.',


### PR DESCRIPTION
## Describe your changes

I fixed one-time appointment logic so that the user couldn't choose identical time and the end time would not exceed the start time.

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.


