### PR TITLE
fix: create custom hook for trimming input spaces

### DIFF
--- a/src/components/account-details/update-password-form/UpdatePassword.tsx
+++ b/src/components/account-details/update-password-form/UpdatePassword.tsx
@@ -1,13 +1,13 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormControl, IconButton, InputAdornment, OutlinedInput } from '@mui/material';
 import { SetStateAction, useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
 
-import { useLocales } from 'src/locales';
 import Visibility from 'src/assets/icons/Visibility';
 import VisibilityOff from 'src/assets/icons/VisibilityOff';
-import { useUpdatePasswordMutation } from 'src/redux/api/userApi';
 import { BAD_REQUEST_STATUS } from 'src/constants';
+import { useLocales } from 'src/locales';
+import { useUpdatePasswordMutation } from 'src/redux/api/userApi';
+import { useCustomForm } from 'src/hooks/useCustomForm';
 
 import { Container, ErrorMessage, StyledButton, StyledForm } from './styles';
 import { FormValues, useUpdatePassword } from './validation';
@@ -36,8 +36,9 @@ export default function UpdatePassword({ email, onClose, onSuccess }: Props): JS
     handleSubmit,
     reset,
     formState: { errors, isValid },
-  } = useForm<FormValues>({
+  } = useCustomForm<FormValues>({
     resolver: yupResolver(updatePassSchema),
+    trim: true,
     mode: 'onChange',
   });
 

--- a/src/hooks/useCustomForm.ts
+++ b/src/hooks/useCustomForm.ts
@@ -1,0 +1,38 @@
+import {
+  useForm,
+  UseFormProps,
+  RegisterOptions,
+  FieldValues,
+  ChangeHandler,
+  Path,
+} from 'react-hook-form';
+
+export interface UseCustomFormProps<FormValues extends FieldValues = FieldValues>
+  extends UseFormProps<FormValues> {
+  trim?: boolean;
+}
+
+export const useCustomForm = <FormValues extends FieldValues>({
+  trim,
+  ...props
+}: UseCustomFormProps<FormValues>) => {
+  const methods = useForm<FormValues>(props);
+
+  const customRegister = (name: Path<FormValues>, registerOptions?: RegisterOptions) => {
+    const field = methods.register(name, registerOptions);
+
+    const customOnChange: ChangeHandler = async (event) => {
+      const { target } = event;
+
+      if (trim && typeof target.value === 'string' && target.value) {
+        target.value = target.value.trim();
+      }
+
+      field.onChange(event);
+    };
+
+    return { ...field, onChange: customOnChange };
+  };
+
+  return { ...methods, register: customRegister };
+};


### PR DESCRIPTION
## Describe your changes

- I added a custom hook for trimming input values. Now if it's needed, field 'trim' can be passed to useForm and it would get rid of spaces in inputs.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-317)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [ ] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.

