### PR TITLE
feat: add avatar from db to all components

### DIFF
--- a/src/components/account-details/AccountDetails.tsx
+++ b/src/components/account-details/AccountDetails.tsx
@@ -137,12 +137,11 @@ export default function AccountDetails({ user }: IProps): JSX.Element | null {
                         onChange={(e): Promise<void> => onFileChange(e, field)}
                       />
                     </Button>
-                    {user.avatar ||
-                      (avatar && (
-                        <IconButton onClick={onDeleteAvatar}>
-                          <DeleteOutlineIcon color="primary" />
-                        </IconButton>
-                      ))}
+                    {(user.avatar || avatar) && (
+                      <IconButton onClick={onDeleteAvatar}>
+                        <DeleteOutlineIcon color="primary" />
+                      </IconButton>
+                    )}
                   </ButtonContainer>
                 )}
               />

--- a/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
+++ b/src/components/appointments/appointment-drawer/AppointmentDrawer.tsx
@@ -10,8 +10,6 @@ import AgreementModal from 'src/components/appointments/agreement-modal/Agreemen
 import AppointmentStatus from 'src/components/appointments/appointment-status/AppointmentStatus';
 import CancelModal from 'src/components/appointments/cancel-modal/CancelModal';
 import CompleteAppointmentModal from 'src/components/appointments/complete-appointment-modal/CompleteAppointmentModal';
-import { SMALL_CAREGIVER_AVATAR_SIZE } from 'src/components/appointments/constants';
-import { getMockCaregiverAvatar } from 'src/components/appointments/helpers';
 import { STEPS } from 'src/components/health-questionnaire/constants';
 import Drawer from 'src/components/reusable/drawer/Drawer';
 import { DrawerFooter, DrawerHeader, DrawerTitle } from 'src/components/reusable/drawer/styles';
@@ -21,12 +19,14 @@ import {
   DATE_FORMAT,
   USER_ROLE,
   VIRTUAL_ASSESSMENT_STATUS,
+  SMALL_AVATAR_SIZE,
 } from 'src/constants';
 import { useLocales } from 'src/locales';
 
 import VirtualAssessmentSuccess from 'src/components/appointments/request-sent-modal/VirtualAssessmentSuccess';
 import VirtualAssessmentModal from 'src/components/appointments/virtual-assessment-modal/VirtualAssessmentModal';
 import VirtualAssessmentRequestModal from 'src/components/virtual-assessment-request/VirtualAssessmentRequest';
+import UserAvatar from 'src/components/reusable/user-avatar/UserAvatar';
 import { useUpdateAppointmentMutation } from 'src/redux/api/appointmentApi';
 
 import { ChildModal } from 'src/components/appointment-request-modal/ChildModal';
@@ -56,7 +56,6 @@ import {
   DateText,
   DisabledText,
   DoubleButtonBox,
-  DrawerAvatar,
   DrawerBody,
   ModalFooter,
   StyledButton,
@@ -290,10 +289,7 @@ export default function AppointmentDrawer({
             <Block>
               <SubTitle>{translate('appointments_page.drawer.caregiver')}</SubTitle>
               <CaregiverBlock>
-                <DrawerAvatar
-                  src={getMockCaregiverAvatar(SMALL_CAREGIVER_AVATAR_SIZE)}
-                  alt={`${appointment?.caregiverInfo.user.firstName} ${appointment?.caregiverInfo.user.lastName}`}
-                />
+                <UserAvatar userId={appointment.caregiverInfo.user.id} size={SMALL_AVATAR_SIZE} />
                 <CaregiverName>
                   {appointment?.caregiverInfo.user.firstName}{' '}
                   {appointment?.caregiverInfo.user.lastName}
@@ -313,10 +309,7 @@ export default function AppointmentDrawer({
             <Block>
               <SubTitle>{translate('appointments_page.drawer.patient')}</SubTitle>
               <CaregiverBlock>
-                <DrawerAvatar
-                  src={getMockCaregiverAvatar(SMALL_CAREGIVER_AVATAR_SIZE)}
-                  alt={`${appointment?.user.firstName} ${appointment?.user.lastName}`}
-                />
+                <UserAvatar userId={appointment.user.id} size={SMALL_AVATAR_SIZE} />
                 <CaregiverName>
                   {appointment?.user.firstName} {appointment?.user.lastName}
                 </CaregiverName>
@@ -461,6 +454,7 @@ export default function AppointmentDrawer({
         <VirtualAssessmentModal
           purpose={AssessmentPurpose.request}
           caregiverName={`${appointment?.caregiverInfo.user.firstName} ${appointment?.caregiverInfo.user.lastName}`}
+          caregiverId={appointment.caregiverInfo.user.id}
           appointmentId={selectedAppointmentId}
           onClose={handleVirtualAssessmentModalClose}
           isActive={isVirtualAssessmentModalOpen && !appointment.virtualAssessment?.wasRescheduled}

--- a/src/components/appointments/appointment-drawer/styles.ts
+++ b/src/components/appointments/appointment-drawer/styles.ts
@@ -1,4 +1,4 @@
-import { Avatar, Button, IconButton, Typography, styled } from '@mui/material';
+import { Button, IconButton, Typography, styled } from '@mui/material';
 import { PRIMARY, SECONDARY, TEXT_COLOR } from 'src/theme/colors';
 import { TYPOGRAPHY } from 'src/theme/fonts';
 import typography from 'src/theme/typography';
@@ -50,11 +50,6 @@ export const CaregiverName = styled('p')`
   font-weight: ${typography.fontWeightMedium};
   line-height: 1.2;
   letter-spacing: 0.15px;
-`;
-
-export const DrawerAvatar = styled(Avatar)`
-  width: 48px;
-  height: 48px;
 `;
 
 export const StyledIconButton = styled(IconButton)`

--- a/src/components/appointments/complete-appointment-modal/CompleteAppointmentModal.tsx
+++ b/src/components/appointments/complete-appointment-modal/CompleteAppointmentModal.tsx
@@ -2,11 +2,10 @@ import { MouseEvent } from 'react';
 import { ChevronRight } from '@mui/icons-material';
 
 import { useLocales } from 'src/locales';
-import { USER_ROLE } from 'src/constants';
+import { USER_ROLE, SMALL_AVATAR_SIZE } from 'src/constants';
 import Cross from 'src/assets/icons/Cross';
-import { SMALL_CAREGIVER_AVATAR_SIZE } from 'src/components/appointments/constants';
-import { getMockCaregiverAvatar } from 'src/components/appointments/helpers';
 import { DetailedAppointment } from 'src/redux/api/appointmentApi';
+import UserAvatar from 'src/components/reusable/user-avatar/UserAvatar';
 
 import {
   BackDrop,
@@ -18,7 +17,6 @@ import {
   ModalBody,
   CaregiverBlock,
   CaregiverName,
-  DrawerAvatar,
   StyledIconButton,
   SubTitle,
   TaskList,
@@ -83,10 +81,7 @@ export default function CompleteAppointmentModal({
             <Block>
               <SubTitle>{translate('appointments_page.drawer.caregiver')}</SubTitle>
               <CaregiverBlock>
-                <DrawerAvatar
-                  src={getMockCaregiverAvatar(SMALL_CAREGIVER_AVATAR_SIZE)}
-                  alt={`${appointment.caregiverInfo.user.firstName} ${appointment.caregiverInfo.user.lastName}`}
-                />
+                <UserAvatar userId={appointment.caregiverInfo.user.id} size={SMALL_AVATAR_SIZE} />
                 <CaregiverName>
                   {appointment.caregiverInfo.user.firstName}{' '}
                   {appointment.caregiverInfo.user.lastName}
@@ -97,10 +92,7 @@ export default function CompleteAppointmentModal({
             <Block>
               <SubTitle>{translate('appointments_page.drawer.patient')}</SubTitle>
               <CaregiverBlock>
-                <DrawerAvatar
-                  src={getMockCaregiverAvatar(SMALL_CAREGIVER_AVATAR_SIZE)}
-                  alt={`${appointment?.user.firstName} ${appointment?.user.lastName}`}
-                />
+                <UserAvatar userId={appointment.user.id} size={SMALL_AVATAR_SIZE} />
                 <CaregiverName>
                   {appointment?.user.firstName} {appointment?.user.lastName}
                 </CaregiverName>

--- a/src/components/appointments/constants.ts
+++ b/src/components/appointments/constants.ts
@@ -1,10 +1,8 @@
 import { DATE_FORMAT } from 'src/constants';
 import { format } from 'date-fns';
 
-export const SMALL_CAREGIVER_AVATAR_SIZE = 48;
 export const DRAWER_DATE_FORMAT = 'dd MMM, HH:mm';
 export const CURRENT_DATE = format(Date.now(), DATE_FORMAT);
 export const PAYMENT_DAY = '1 day';
 export const MILEAGE_PRICE = 20;
 export const RENT_PRICE = 400;
-export const MOCK_USER_AVATAR_URL = 'https://picsum.photos';

--- a/src/components/appointments/helpers.ts
+++ b/src/components/appointments/helpers.ts
@@ -1,8 +1,5 @@
 import { format, parseISO, differenceInHours } from 'date-fns';
-import { DRAWER_DATE_FORMAT, MOCK_USER_AVATAR_URL } from './constants';
-
-export const getMockCaregiverAvatar = (size: number): string =>
-  `${MOCK_USER_AVATAR_URL}/${size}/${size}`;
+import { DRAWER_DATE_FORMAT } from './constants';
 
 export const getFormattedDate = (date: string): string =>
   format(parseISO(date), DRAWER_DATE_FORMAT);

--- a/src/components/appointments/virtual-assessment-modal/VirtualAssessmentModal.tsx
+++ b/src/components/appointments/virtual-assessment-modal/VirtualAssessmentModal.tsx
@@ -1,6 +1,6 @@
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
-import { Alert, Avatar, IconButton, Snackbar, TextField } from '@mui/material';
+import { Alert, IconButton, Snackbar, TextField } from '@mui/material';
 import { isBefore, isSameDay } from 'date-fns';
 
 import Cross from 'src/assets/icons/Cross';
@@ -9,8 +9,9 @@ import { CloseButton, HeaderTitle } from 'src/components/confirm-appointment/sty
 import Appointment from 'src/components/create-appointment/Appointment';
 import { selectTimeOptions } from 'src/components/create-appointment/constants';
 import { ErrorText, FilledButton } from 'src/components/reusable';
+import UserAvatar from 'src/components/reusable/user-avatar/UserAvatar';
 import { useLocales } from 'src/locales';
-import { CURRENT_DAY } from 'src/constants';
+import { CURRENT_DAY, SMALL_AVATAR_SIZE } from 'src/constants';
 
 import {
   AppointmentModal,
@@ -43,6 +44,7 @@ type Props = {
   openCaregiverProfile?: () => void;
   openVirtualAssessmentSuccess: () => void;
   caregiverName: string;
+  caregiverId: string;
   appointmentId: string;
 };
 
@@ -54,6 +56,7 @@ export default function VirtualAssessmentModal({
   openCaregiverProfile,
   openVirtualAssessmentSuccess,
   caregiverName,
+  caregiverId,
   appointmentId,
 }: Props): JSX.Element | null {
   const { translate } = useLocales();
@@ -119,7 +122,7 @@ export default function VirtualAssessmentModal({
                   {translate('request_appointment.caregiver')}
                 </AppointmentModalBlockParagraph>
                 <InlineBlock>
-                  <Avatar />
+                  <UserAvatar userId={caregiverId} size={SMALL_AVATAR_SIZE} />
                   <NameParagraph>{caregiverName}</NameParagraph>
                   <StyledIconButton color="secondary" onClick={openCaregiverProfile}>
                     <RightAction />

--- a/src/components/caregiver-schedule/CaregiverAppointment.tsx
+++ b/src/components/caregiver-schedule/CaregiverAppointment.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '@mui/material';
 import AccessTimeIcon from 'src/assets/icons/AccessTimeIcon';
 import AppointmentStatus from 'src/components/appointments/appointment-status/AppointmentStatus';
-import { DISPLAY_TIME_FORMAT } from 'src/constants';
+import { DISPLAY_TIME_FORMAT, TINY_AVATAR_SIZE } from 'src/constants';
 import { useLocales } from 'src/locales';
 import { formatTimeToTimezone } from 'src/utils/formatTime';
 import {
@@ -9,7 +9,6 @@ import {
   AppointmentHeader,
   AppointmentInfo,
   Arrow,
-  AvatarIcon,
   Details,
   HeaderText,
   Task,
@@ -17,6 +16,7 @@ import {
   Text,
 } from './styles';
 import { CaregiverAppointmentI } from './types';
+import UserAvatar from '../reusable/user-avatar/UserAvatar';
 
 type Props = {
   appointmentDays: CaregiverAppointmentI[];
@@ -49,7 +49,7 @@ export default function CaregiverAppointment({ appointmentDays, openDrawer }: Pr
                 </Text>
               </Details>
               <Details>
-                <AvatarIcon />
+                <UserAvatar userId={appointment.user.id} size={TINY_AVATAR_SIZE} />
                 <Text>{`${appointment.user.firstName} ${appointment.user.lastName}`}</Text>
               </Details>
             </AppointmentDetails>

--- a/src/components/caregiver-schedule/styles.ts
+++ b/src/components/caregiver-schedule/styles.ts
@@ -1,5 +1,5 @@
 import { ArrowForwardIos } from '@mui/icons-material';
-import { Avatar, Typography, styled } from '@mui/material';
+import { Typography, styled } from '@mui/material';
 import { FilledButton } from 'src/components/reusable';
 import { HEADER } from 'src/config-global';
 import { PRIMARY, SECONDARY } from 'src/theme/colors';
@@ -157,11 +157,6 @@ const Arrow = styled(ArrowForwardIos)`
   }
 `;
 
-const AvatarIcon = styled(Avatar)`
-  width: 24px;
-  height: 24px;
-`;
-
 const Text = styled('span')`
   color: ${SECONDARY.grayish};
   font-size: ${TYPOGRAPHY.base}px;
@@ -180,7 +175,6 @@ export {
   AppointmentInfo,
   AppointmentsContainer,
   Arrow,
-  AvatarIcon,
   Background,
   BaseText,
   CalendarBtn,

--- a/src/components/confirm-appointment/ConfirmAppointment.tsx
+++ b/src/components/confirm-appointment/ConfirmAppointment.tsx
@@ -1,5 +1,4 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { Avatar } from '@mui/material';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
@@ -7,15 +6,17 @@ import ArrowForward from 'src/assets/icons/ArrowForward';
 import TasksList from 'src/components/confirm-appointment/TasksList';
 import { Appointment } from 'src/components/create-appointment/enums';
 import AppointmentBtn from 'src/components/reusable/appointment-btn/AppointmentBtn';
-import { APPOINTMENT_STATUS } from 'src/constants';
+import { APPOINTMENT_STATUS, SMALL_AVATAR_SIZE } from 'src/constants';
 import { useLocales } from 'src/locales';
 import { useCreateAppointmentMutation } from 'src/redux/api/appointmentApi';
 import { useAppDispatch, useTypedSelector } from 'src/redux/store';
 import { ROUTES } from 'src/routes';
 
 import CaregiverDrawer from 'src/components/reusable/drawer/caregiver-drawer/CaregiverDrawer';
+import UserAvatar from 'src/components/reusable/user-avatar/UserAvatar';
 import { cancelAppointment as resetAppointmentInfo } from 'src/redux/slices/appointmentSlice';
 import { resetAllInfo } from 'src/redux/slices/healthQuestionnaireSlice';
+
 import { CONFIRM_NOTE_MAX_LENGTH } from './constants';
 import {
   Container,
@@ -101,7 +102,7 @@ export default function ConfirmAppointment({ onBack }: { onBack: () => void }): 
           <Header>
             <Typography>{translate('confirm_appointment.caregiver')}</Typography>
             <LinkToProfile onClick={openDrawer}>
-              <Avatar />
+              {caregiver && <UserAvatar userId={caregiver.id} size={SMALL_AVATAR_SIZE} />}
               <Name>{`${caregiver?.firstName} ${caregiver?.lastName}`}</Name>
               <ArrowForward />
             </LinkToProfile>

--- a/src/components/create-appointment-fourth/CreateAppointmentFourth.tsx
+++ b/src/components/create-appointment-fourth/CreateAppointmentFourth.tsx
@@ -11,11 +11,8 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import MonetizationOn from 'src/assets/icons/MonetizationOn';
 import RightAction from 'src/assets/icons/RightAction';
-import { SMALL_CAREGIVER_AVATAR_SIZE } from 'src/components/create-appointment-fourth/constants';
-import {
-  getMockCaregiverAvatar,
-  serializeCaregiverFilterStateToQueryString,
-} from 'src/components/create-appointment-fourth/helpers';
+import { SMALL_AVATAR_SIZE } from 'src/constants';
+import { serializeCaregiverFilterStateToQueryString } from 'src/components/create-appointment-fourth/helpers';
 import {
   useCaregiverFilter,
   useCreateAppointmentFourth,
@@ -26,7 +23,6 @@ import {
   BaseText,
   CaregiverListContainer,
   FilterContainer,
-  StyledAvatar,
   StyledFormControlLabel,
   StyledListItemText,
   StyledNextButton,
@@ -34,6 +30,7 @@ import {
 import { appointmentApi } from 'src/redux/api/appointmentApi';
 import { useTypedSelector } from 'src/redux/store';
 import CreateAppointmentFourthDrawer from './CreateAppointmentFourthDrawer';
+import UserAvatar from '../reusable/user-avatar/UserAvatar';
 
 interface CreateAppointmentFourthProps {
   onNext: () => void;
@@ -126,11 +123,9 @@ export default function CreateAppointmentFourth({
                 }
               >
                 <ListItemAvatar>
-                  <StyledAvatar
-                    src={getMockCaregiverAvatar(SMALL_CAREGIVER_AVATAR_SIZE)}
-                    alt={`${caregiver.firstName} ${caregiver.lastName}`}
-                  />
+                  <UserAvatar userId={caregiver.id} size={SMALL_AVATAR_SIZE} />
                 </ListItemAvatar>
+
                 <StyledListItemText
                   primary={`${caregiver.firstName} ${caregiver.lastName}`}
                   secondary={

--- a/src/components/create-appointment-fourth/constants.ts
+++ b/src/components/create-appointment-fourth/constants.ts
@@ -1,2 +1,0 @@
-export const SMALL_CAREGIVER_AVATAR_SIZE = 48;
-export const BIG_CAREGIVER_AVATAR_SIZE = 96;

--- a/src/components/create-appointment-fourth/helpers.ts
+++ b/src/components/create-appointment-fourth/helpers.ts
@@ -46,6 +46,3 @@ export const serializeCaregiverFilterStateToQueryString = (
 
   return searchParams;
 };
-
-export const getMockCaregiverAvatar = (size: number): string =>
-  `https://picsum.photos/${size}/${size}`;

--- a/src/components/create-appointment-fourth/styles.ts
+++ b/src/components/create-appointment-fourth/styles.ts
@@ -1,4 +1,4 @@
-import { Avatar, FormControlLabel, ListItemText, Typography, styled } from '@mui/material';
+import { FormControlLabel, ListItemText, Typography, styled } from '@mui/material';
 import { NextButton } from 'src/components/reusable/appointment-btn/styles';
 import { HEADER } from 'src/config-global';
 import { PRIMARY, SECONDARY } from 'src/theme/colors';
@@ -42,11 +42,6 @@ export const StyledFormControlLabel = styled(FormControlLabel)`
     font-size: ${TYPOGRAPHY.base}px;
     font-weight: ${typography.fontWeightMedium};
   }
-`;
-
-export const StyledAvatar = styled(Avatar)`
-  width: 48px;
-  height: 48px;
 `;
 
 export const StyledListItemText = styled(ListItemText)`

--- a/src/components/reusable/drawer/caregiver-drawer/CaregiverDrawer.tsx
+++ b/src/components/reusable/drawer/caregiver-drawer/CaregiverDrawer.tsx
@@ -6,6 +6,7 @@ import FreeCancellation from 'src/assets/icons/FreeCancellation';
 import MonetizationOn from 'src/assets/icons/MonetizationOn';
 
 import Drawer from 'src/components/reusable/drawer/Drawer';
+import UserAvatar from 'src/components/reusable/user-avatar/UserAvatar';
 import {
   DrawerBody,
   DrawerFooter,
@@ -14,12 +15,11 @@ import {
 } from 'src/components/reusable/drawer/styles';
 import { useLocales } from 'src/locales';
 import { appointmentApi } from 'src/redux/api/appointmentApi';
+import { BIG_AVATAR_SIZE } from 'src/constants';
 
-import { getMockCaregiverAvatar } from 'src/components/create-appointment-fourth/helpers';
-import { BIG_CAREGIVER_AVATAR_SIZE, FIRST_SELECTED_TAB } from './constants';
+import { FIRST_SELECTED_TAB } from './constants';
 import { formatWorkExperienceDateRange, formatWorkExperienceDateRangeTenure } from './helpers';
 import {
-  DrawerAvatar,
   DrawerDateTenure,
   DrawerItem,
   DrawerStats,
@@ -73,10 +73,7 @@ export default function CaregiverDrawer({
         </DrawerTitle>
       </DrawerHeader>
       <DrawerStats flexDirection="row">
-        <DrawerAvatar
-          src={getMockCaregiverAvatar(BIG_CAREGIVER_AVATAR_SIZE)}
-          alt={`${selectedCaregiver.firstName} ${selectedCaregiver.lastName}`}
-        />
+        <UserAvatar userId={selectedCaregiver.id} size={BIG_AVATAR_SIZE} />
         <StyledStack>
           <Stack flexDirection="column" alignItems="center">
             <FreeCancellation />

--- a/src/components/reusable/drawer/caregiver-drawer/constants.ts
+++ b/src/components/reusable/drawer/caregiver-drawer/constants.ts
@@ -1,2 +1,1 @@
 export const FIRST_SELECTED_TAB = '1';
-export const BIG_CAREGIVER_AVATAR_SIZE = 96;

--- a/src/components/reusable/drawer/caregiver-drawer/styles.ts
+++ b/src/components/reusable/drawer/caregiver-drawer/styles.ts
@@ -1,5 +1,5 @@
 import { TabPanel } from '@mui/lab';
-import { Avatar, Button, Grid, List, Stack, Tab, Tabs, Typography, styled } from '@mui/material';
+import { Button, Grid, List, Stack, Tab, Tabs, Typography, styled } from '@mui/material';
 import Link from 'next/link';
 import { PRIMARY, SECONDARY } from 'src/theme/colors';
 import { TYPOGRAPHY } from 'src/theme/fonts';
@@ -8,11 +8,6 @@ import typography from 'src/theme/typography';
 export const BookButton = styled(Button)`
   width: 100%;
   border-radius: 4px;
-`;
-
-export const DrawerAvatar = styled(Avatar)`
-  width: 96px;
-  height: 96px;
 `;
 
 export const DrawerItem = styled(Stack)`
@@ -98,4 +93,4 @@ export const StyledStack = styled(Stack)`
   flex-direction: row;
   justify-content: space-evenly;
   width: 100%;
-`
+`;

--- a/src/components/reusable/header/MainHeader.tsx
+++ b/src/components/reusable/header/MainHeader.tsx
@@ -8,6 +8,7 @@ import { USER_ROLE } from 'src/constants';
 import { useLocales } from 'src/locales';
 import { useTypedSelector } from 'src/redux/store';
 import { ROUTES } from 'src/routes';
+import { useGetUserInfoQuery } from 'src/redux/api/userApi';
 import MenuDropdown from './Menu';
 import {
   AppointmentsSection,
@@ -23,7 +24,6 @@ import {
   ProfileSection,
   SecondPart,
 } from './styles';
-import { ActiveTab } from './types';
 
 type Props = {
   isCalendarVisible?: boolean;
@@ -37,7 +37,9 @@ export default function MainHeader({
   const { translate } = useLocales();
   const { push, route } = useRouter();
 
-  const user = useTypedSelector((state) => state.user.user);
+  const userId = useTypedSelector((state) => state.user.user?.id);
+
+  const { data: user } = useGetUserInfoQuery(userId);
 
   const [isMenuVisible, setIsMenuVisible] = useState<boolean>(false);
 
@@ -87,7 +89,7 @@ export default function MainHeader({
         </IconWrapper>
         <ProfileSection>
           <AvatarWrapper>
-            <Avatar />
+            <Avatar src={user.avatar} />
           </AvatarWrapper>
           <ProfileName>{`${firstName} ${lastName}`}</ProfileName>
           <MenuDropdown onClick={openMenu}>

--- a/src/components/reusable/user-avatar/UserAvatar.tsx
+++ b/src/components/reusable/user-avatar/UserAvatar.tsx
@@ -1,0 +1,19 @@
+import { Avatar } from '@mui/material';
+import { useGetUserInfoQuery } from 'src/redux/api/userApi';
+
+type Props = {
+  userId: string;
+  size: number;
+};
+
+export default function UserAvatar({ userId, size }: Props): JSX.Element {
+  const { data: user } = useGetUserInfoQuery(userId);
+
+  return (
+    <Avatar
+      src={user?.avatar}
+      sx={{ width: size, height: size }}
+      alt={`${user?.firstName} ${user?.lastName}`}
+    />
+  );
+}

--- a/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
+++ b/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
@@ -1,7 +1,7 @@
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
-import { Avatar, Button, IconButton, List, ListItemText, Typography } from '@mui/material';
+import { Button, IconButton, List, ListItemText, Typography } from '@mui/material';
 import { format } from 'date-fns';
 import jwt_decode from 'jwt-decode';
 import { useMemo, useState } from 'react';
@@ -10,9 +10,10 @@ import { DRAWER_DATE_FORMAT } from 'src/components/appointments/constants';
 import VirtualAssessmentSuccess from 'src/components/appointments/request-sent-modal/VirtualAssessmentSuccess';
 import VirtualAssessmentModal from 'src/components/appointments/virtual-assessment-modal/VirtualAssessmentModal';
 import { AssessmentPurpose } from 'src/components/appointments/virtual-assessment-modal/enums';
+import UserAvatar from 'src/components/reusable/user-avatar/UserAvatar';
 import { FilledButton } from 'src/components/reusable';
 import FlowHeader from 'src/components/reusable/header/FlowHeader';
-import { USER_ROLE, VIRTUAL_ASSESSMENT_STATUS } from 'src/constants';
+import { SMALL_AVATAR_SIZE, USER_ROLE, VIRTUAL_ASSESSMENT_STATUS } from 'src/constants';
 import { useLocales } from 'src/locales';
 import { virtualAssessmentApi } from 'src/redux/api/virtualAssessmentApi';
 import { useTypedSelector } from 'src/redux/store';
@@ -118,7 +119,7 @@ const VirtualAssessmentRequestModal = ({
               {translate('request_appointment.client')}
             </AppointmentModalBlockParagraph>
             <InlineBlock>
-              <Avatar />
+              <UserAvatar userId={appointment.user.id} size={SMALL_AVATAR_SIZE} />
               <NameParagraph>{`${appointment.user.firstName} ${appointment.user.lastName}`}</NameParagraph>
             </InlineBlock>
           </AppointmentModalBlock>
@@ -214,6 +215,7 @@ const VirtualAssessmentRequestModal = ({
       <VirtualAssessmentModal
         purpose={AssessmentPurpose.reschedule}
         caregiverName={`${appointment?.caregiverInfo.user.firstName} ${appointment?.caregiverInfo.user.lastName}`}
+        caregiverId={appointment.caregiverInfo.user.id}
         appointmentId={appointment.id}
         onClose={closeReschedulingModal}
         isActive={reschedulingModalOpen && !appointment.virtualAssessment?.wasRescheduled}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -72,3 +72,6 @@ export const APPOINTMENT_TYPE = {
 
 export const HELP_EMAIL = 'help@ctrlchamps@gmail.com';
 export const TRANSACTION_EXAMPLE = 100;
+export const TINY_AVATAR_SIZE = 24;
+export const SMALL_AVATAR_SIZE = 48;
+export const BIG_AVATAR_SIZE = 96;

--- a/src/redux/api/userApi.ts
+++ b/src/redux/api/userApi.ts
@@ -83,6 +83,7 @@ export const userApi = createApi({
           body: formData,
         };
       },
+      invalidatesTags: (result, error, { file }) => [{ type: 'User', file }, 'User'],
     }),
     updatePassword: builder.mutation<void, UserPasswordData>({
       query: ({ ...passwordData }) => ({


### PR DESCRIPTION
## Describe your changes

- added user avatar reusable component;
- added user photo from database to main header, appointment drawer, modals, schedule page, create appointment(caregivers list, confirm appointment), caregiver drawer;
- updated userApi;
- moved avatar sizes to global constants;
- removed get mocked avatar function.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-254)

header:
<img width="648" alt="Снимок экрана 2024-01-04 203003" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/36adacf2-791a-4164-954a-4a2102b5e565">

appointment drawer:
<img width="546" alt="Снимок экрана 2024-01-04 192210" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/a0a67aa3-12e9-4cdb-b38b-8f72dfa43387">

caregiver drawer:
<img width="549" alt="Снимок экрана 2024-01-04 192222" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/6bb2540f-5acd-45e9-8b6e-98a830016a86">

caregivers list:
<img width="628" alt="Снимок экрана 2024-01-04 193155" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/d87fe7a0-0749-44eb-a583-fe9d71640854">

confirm appointment:
<img width="637" alt="Снимок экрана 2024-01-04 193638" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/efbcaf80-6ea4-429c-9671-ce4210147216">

virtual assessment:
<img width="635" alt="Снимок экрана 2024-01-04 195024" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/eca40e30-65bc-4ca7-92e3-88177030bdd2">
<img width="546" alt="Снимок экрана 2024-01-04 195146" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/66656a36-d775-4555-8073-651fe126786b">
<img width="560" alt="Снимок экрана 2024-01-04 195200" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/0cc10fbc-c39b-4c96-ae29-c9104da6d2b3">

schedule page:
<img width="649" alt="Снимок экрана 2024-01-04 200416" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/60821861-d5fe-401e-a281-e9170b5ae2b7">

complete appointment modal:
<img width="350" alt="Снимок экрана 2024-01-04 202418" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/6a9bf278-aaee-4763-a458-0c4988d56c05">

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.