### PR TITLE
fix: fix custom tasks deleting logic + add invalidation tag for creat…

### DIFF
--- a/src/components/confirm-appointment/TasksList.tsx
+++ b/src/components/confirm-appointment/TasksList.tsx
@@ -96,9 +96,11 @@ export default function TasksList({
   };
 
   const deleteCustomTask = (task: string): void => {
-    const filteredTasks = customTasks.filter((el) => el !== task);
-    setCustomTasks(filteredTasks);
-    setChosenTasks(filteredTasks);
+    const filterTasks = (tasksToFilter: string[]): string[] =>
+      tasksToFilter.filter((el) => el !== task);
+
+    setChosenTasks(filterTasks(chosenTasks));
+    setCustomTasks(filterTasks(customTasks));
   };
 
   return (

--- a/src/redux/api/appointmentApi.ts
+++ b/src/redux/api/appointmentApi.ts
@@ -155,6 +155,7 @@ export const appointmentApi = createApi({
         method: 'POST',
         body,
       }),
+      invalidatesTags: ['Appointments'],
     }),
     getFilteredCaregivers: builder.query<PreviewCaregiver[], URLSearchParams>({
       query: (params) => ({ url: `${route.caregivers}${route.filter}`, method: 'GET', params }),


### PR DESCRIPTION
## Describe your changes

- I fixed custom tasks deletion logic - it deleted both custom and chosen tasks. Also, added invalidation tag for the endpoint for creating an appointment. Now, after completing appointment creation, the newly created appointment is visible in the appointments' list.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](#https://ticket-url)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.


