### PR TITLE
fix: work experience date validation

### DIFF
--- a/src/components/complete-profile-second/work-form/WorkForm.tsx
+++ b/src/components/complete-profile-second/work-form/WorkForm.tsx
@@ -58,7 +58,7 @@ export default function WorkForm({ onClose, onSave, editingWorkPlaces }: Props):
     formState: { errors, isValid },
   } = useForm<ProfileExperience>({
     resolver: yupResolver(profileExperienceSchema),
-    mode: 'onBlur',
+    mode: 'onChange',
     defaultValues: editingWorkPlaces ?? DEFAULT_EXPERIENCE_VALUES,
   });
 

--- a/src/components/complete-profile-second/work-form/validation.ts
+++ b/src/components/complete-profile-second/work-form/validation.ts
@@ -1,7 +1,8 @@
 import { ObjectSchema, boolean, date, object, string } from 'yup';
-import { MAX_CHARACTERS_LENGTH, CURRENT_DAY } from 'src/constants';
+import { MAX_CHARACTERS_LENGTH, CURRENT_DAY, DATE_FORMAT, ONE_DAY } from 'src/constants';
 import { useLocales } from 'src/locales';
 import { CompleteProfileSecondValues } from 'src/components/complete-profile-second/types';
+import { isAfter, isBefore, isValid, parse } from 'date-fns';
 
 export const useProfileExperienceSchema = (): ObjectSchema<CompleteProfileSecondValues> => {
   const { translate } = useLocales();
@@ -15,12 +16,49 @@ export const useProfileExperienceSchema = (): ObjectSchema<CompleteProfileSecond
       .trim()
       .required(translate('completeProfileSecond.errors.workTypeRequired')),
     startDate: date()
-      .max(CURRENT_DAY, translate('completeProfileSecond.errors.startDateMax'))
-      .required(translate('completeProfileSecond.errors.startDateRequired')),
+      .required(translate('completeProfileSecond.errors.startDateRequired'))
+      .transform((value, originalValue) => {
+        if (typeof originalValue === 'string') {
+          const parsedDate = parse(originalValue, DATE_FORMAT, CURRENT_DAY);
+
+          return isValid(parsedDate);
+        }
+
+        return value;
+      })
+      .typeError(translate('completeProfileSecond.errors.invalidDateFormat'))
+      .test(
+        'is-future-date',
+        translate('completeProfileSecond.errors.startDateMax'),
+        (value) => !isAfter(value, CURRENT_DAY)
+      ),
+
     isEndDateDisabled: boolean().required(),
     endDate: date().when('isEndDateDisabled', {
       is: false,
-      then: (schema) => schema.required(translate('completeProfileSecond.errors.endDateRequired')),
+      then: (schema) =>
+        schema
+          .required(translate('completeProfileSecond.errors.endDateRequired'))
+          .test(
+            'is-after-startDate',
+            translate('completeProfileSecond.errors.endDateCannotBeBeforeStartDate'),
+            (value, context) => {
+              const { startDate } = context.parent;
+
+              return !startDate || isBefore(startDate - ONE_DAY, value);
+            }
+          )
+          .transform((value, originalValue) => {
+            if (typeof originalValue === 'string') {
+              const parsedDate = parse(originalValue, DATE_FORMAT, CURRENT_DAY);
+
+              return isValid(parsedDate);
+            }
+
+            return value;
+          })
+          .typeError(translate('completeProfileSecond.errors.invalidDateFormat'))
+          .max(CURRENT_DAY, translate('completeProfileSecond.errors.endDateMax')),
       otherwise: (schema) => schema.notRequired(),
     }),
   }) as ObjectSchema<CompleteProfileSecondValues>;

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -272,8 +272,11 @@ const en = {
       workPlaceLength: `Work place must be at most ${MAX_CHARACTERS_LENGTH} characters`,
       workTypeRequired: 'Work type is required',
       startDateRequired: 'Start date is required',
-      startDateMax: 'Start date cannot exceed today`s date',
+      startDateMax: 'Start date cannot be in future',
       endDateRequired: 'End date is required',
+      endDateCannotBeBeforeStartDate: 'End date cannot be before start date',
+      invalidDateFormat: 'Entered data has an invalid format',
+      endDateMax: 'End date cannot be in future',
     },
   },
   completeProfileThird: {


### PR DESCRIPTION
## Describe your changes

- updated work experience date validation;
- added error messages

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-267)

<img width="285" alt="Снимок экрана 2024-01-08 170511" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/953f34f1-4703-4afa-958c-1b602a65ef20">
<img width="343" alt="Снимок экрана 2024-01-08 170713" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/59f5c3a3-7364-484a-8cfd-027df59fe021">
<img width="266" alt="Снимок экрана 2024-01-08 170727" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/48548b46-f572-43c1-b660-67bac24aa4a3">
<img width="366" alt="Снимок экрана 2024-01-08 171320" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/799eb8f4-4c52-4a11-96bf-f2d439ab7d1b">


### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.