### PR TITLE
fix: added top-up/withdrawal fix, no button inactive if request in pr…

### DIFF
--- a/src/components/reusable/header/Menu.tsx
+++ b/src/components/reusable/header/Menu.tsx
@@ -52,13 +52,14 @@ const MenuDropdown: React.FC<MenuDropdownProps> = ({ children, onClick }): JSX.E
 
   const open = Boolean(anchorEl);
   const [isUpdatingBalance, setIsUpdatingBalance] = useState<boolean>(false);
-  const { role } = user || {};
 
   useEffect(() => {
     refetch();
   }, [refetch]);
 
   if (!user) return null;
+
+  const { role } = user;
 
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
     setAnchorEl(event.currentTarget);

--- a/src/redux/api/transactionsApi.ts
+++ b/src/redux/api/transactionsApi.ts
@@ -25,9 +25,11 @@ export const transactionsApi = createApi({
       return headers;
     },
   }),
+  tagTypes: ['Transactions'],
   endpoints: (builder) => ({
     getTransactions: builder.query<Transaction[], string>({
       query: (userId) => ({ url: `${route.transactions}/${userId}` }),
+      providesTags: ['Transactions'],
     }),
     updateBalance: builder.mutation<void, number>({
       query: (balance) => ({
@@ -35,6 +37,10 @@ export const transactionsApi = createApi({
         method: 'PATCH',
         body: { balance },
       }),
+      invalidatesTags: (result, error, balance) => [
+        { type: 'Transactions', balance },
+        'Transactions',
+      ],
     }),
   }),
 });


### PR DESCRIPTION
## Describe your changes

- Now block button when request in progress + refetch userInfo to show balance properly

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.