### PR TITLE
fix: fix confirm password bug

### DIFF
--- a/src/components/account-details/update-password-form/UpdatePassword.tsx
+++ b/src/components/account-details/update-password-form/UpdatePassword.tsx
@@ -144,7 +144,7 @@ export default function UpdatePassword({ email, onClose, onSuccess }: Props): JS
             id="confirmPassword"
             autoComplete="off"
             placeholder={translate('changePassword.placeholder.confirmPass')}
-            error={!!errors.confirmPassword}
+            error={!!errors.confirmPassword && !isValid}
             type={isConfirmPassVisible ? 'text' : 'password'}
             endAdornment={
               <InputAdornment position="end">
@@ -157,7 +157,7 @@ export default function UpdatePassword({ email, onClose, onSuccess }: Props): JS
               </InputAdornment>
             }
           />
-          {errors?.confirmPassword && (
+          {!isValid && errors?.confirmPassword && (
             <ErrorMessage variant="caption">{errors.confirmPassword?.message}</ErrorMessage>
           )}
         </FormControl>


### PR DESCRIPTION
## Describe your changes

- I fixed update password displaying message. Now the message is not displayed if new password and confirm password fields are valid.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-335)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [ ] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [ ] Components and business logic are separated
- [ ] Colors, Font Size, and Font Name is on the theme or in the constants
- [ ] No text in the components, use i18n approach
- [ ] No inline styles
- [ ] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.

