### PR TITLE
fix: expiration date can be set earlier than today

### DIFF
--- a/src/components/profile/profile-qualification/certificate-form/CertificateForm.tsx
+++ b/src/components/profile/profile-qualification/certificate-form/CertificateForm.tsx
@@ -166,7 +166,7 @@ export default function CertificateForm({
                 {...field}
                 label={translate('profileQualification.placeholderExpirationDate')}
                 inputFormat={DATE_FORMAT}
-                minDate={watch('dateIssued')}
+                minDate={CURRENT_DAY}
                 openTo="year"
                 value={isExpirationDateDisabled ? null : field.value}
                 onChange={(date): void => field.onChange(date)}

--- a/src/components/profile/profile-qualification/certificate-form/validation.ts
+++ b/src/components/profile/profile-qualification/certificate-form/validation.ts
@@ -1,5 +1,5 @@
 import { ObjectSchema, boolean, date, object, string } from 'yup';
-import { isBefore, isValid, parse, isAfter } from 'date-fns';
+import { isBefore, isValid, parse, isAfter, isToday } from 'date-fns';
 
 import { ProfileQualityFormValues } from 'src/components/profile/profile-qualification/types';
 import {
@@ -76,7 +76,12 @@ export const useProfileQualificationSchema = (): ObjectSchema<ProfileQualityForm
 
             return value;
           })
-          .typeError(translate('profileQualification.invalidDateFormat')),
+          .typeError(translate('profileQualification.invalidDateFormat'))
+          .test(
+            'is-after-yesterday',
+            translate('profileQualification.expirationDateCannotBeBeforeToday'),
+            (value) => isToday(value) || isAfter(value, CURRENT_DAY)
+          ),
       otherwise: (schema) => schema.notRequired(),
     }),
   }) as ObjectSchema<ProfileQualityFormValues>;

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -212,6 +212,7 @@ const en = {
     expirationDate: 'Expiration date is required',
 
     expirationDateCannotBeBeforeStartDate: 'Expiration date cannot be before start date',
+    expirationDateCannotBeBeforeToday: 'Expiration date cannot be before today',
     startDateCannotBeInFuture: 'Start date cannot be in future',
     invalidDateFormat: 'Entered data has an invalid format',
 


### PR DESCRIPTION
## Describe your changes

- I fixed bug that expiration date can be set earlier than today.

![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/92392661/5486512c-c0bd-4e5d-8120-4852f8f70b78)
![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/92392661/d431306e-db09-4429-a733-72d2bb20adf0)


## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-328?atlOrigin=eyJpIjoiNzA2ODM1NzMzMzVkNDI2N2I5Yjk5MGM1ZDE0MTcyOWQiLCJwIjoiaiJ9)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.