### PR TITLE
fix: now date and time are converted to UTC format 

### DIFF
--- a/src/components/appointments/appointment-drawer/hooks.ts
+++ b/src/components/appointments/appointment-drawer/hooks.ts
@@ -1,7 +1,8 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 import { USER_ROLE } from 'src/constants';
 import { DetailedAppointment, useGetAppointmentQuery } from 'src/redux/api/appointmentApi';
-import { getFormattedDate } from '../helpers';
+import { formatTimeToTimezone } from 'src/utils/formatTime';
+import { DRAWER_DATE_FORMAT_WITH_TIMEZONE } from '../constants';
 
 interface IProps {
   role: string;
@@ -58,7 +59,13 @@ export function useAppointmentDrawer({
 
   const { data: appointment, isLoading } = useGetAppointmentQuery(selectedAppointmentId);
 
-  const formattedStartDate = appointment && getFormattedDate(appointment.startDate);
+  const formattedStartDate =
+    appointment &&
+    formatTimeToTimezone(
+      appointment?.startDate,
+      appointment?.timezone,
+      DRAWER_DATE_FORMAT_WITH_TIMEZONE
+    );
 
   const virtualAssessmentDrawerShown =
     appointment?.virtualAssessment?.wasRescheduled || role === USER_ROLE.Caregiver;

--- a/src/components/appointments/constants.ts
+++ b/src/components/appointments/constants.ts
@@ -2,6 +2,7 @@ import { DATE_FORMAT } from 'src/constants';
 import { format } from 'date-fns';
 
 export const DRAWER_DATE_FORMAT = 'dd MMM, HH:mm';
+export const DRAWER_DATE_FORMAT_WITH_TIMEZONE = 'dd MMM, HH:mm z';
 export const CURRENT_DATE = format(Date.now(), DATE_FORMAT);
 export const PAYMENT_DAY = '1 day';
 export const MILEAGE_PRICE = 20;

--- a/src/components/appointments/helpers.ts
+++ b/src/components/appointments/helpers.ts
@@ -1,8 +1,4 @@
-import { format, parseISO, differenceInHours } from 'date-fns';
-import { DRAWER_DATE_FORMAT } from './constants';
-
-export const getFormattedDate = (date: string): string =>
-  format(parseISO(date), DRAWER_DATE_FORMAT);
+import { parseISO, differenceInHours } from 'date-fns';
 
 export const getHoursForWeek = (startDate: string, endDate: string): number =>
   differenceInHours(parseISO(startDate), parseISO(endDate));

--- a/src/components/appointments/virtual-assessment-modal/helpers.ts
+++ b/src/components/appointments/virtual-assessment-modal/helpers.ts
@@ -1,0 +1,19 @@
+import { parse } from 'date-fns';
+import { utcToZonedTime } from 'date-fns-tz';
+import { DISPLAY_TIME_FORMAT } from 'src/constants';
+
+export function convertLocalTimeToUTC(
+  localTime: string,
+  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone
+): string {
+  const parsedLocalTime = parse(localTime, DISPLAY_TIME_FORMAT, new Date());
+
+  const utcTime = utcToZonedTime(parsedLocalTime, timeZone);
+
+  const hours = utcTime.getUTCHours();
+  const minutes = utcTime.getUTCMinutes();
+
+  const formattedUTC = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+
+  return formattedUTC;
+}

--- a/src/components/appointments/virtual-assessment-modal/useVirtualAssessmentModal.tsx
+++ b/src/components/appointments/virtual-assessment-modal/useVirtualAssessmentModal.tsx
@@ -16,6 +16,7 @@ import {
   MIN_REASON_LENGTH,
   MIN_VALUE,
 } from './constants';
+import { convertLocalTimeToUTC } from './helpers';
 
 type ReturnType = {
   startTime: string;
@@ -142,8 +143,8 @@ export default function useVirtualAssessmentModal(
       if (!isLoading) setServerError(false);
 
       await requestVirtualAssessment({
-        startTime,
-        endTime,
+        startTime: convertLocalTimeToUTC(startTime),
+        endTime: convertLocalTimeToUTC(endTime),
         assessmentDate: format(date, BACKEND_DATE_FORMAT),
         meetingLink,
         appointmentId,

--- a/src/components/confirm-appointment/ConfirmAppointment.tsx
+++ b/src/components/confirm-appointment/ConfirmAppointment.tsx
@@ -17,6 +17,7 @@ import UserAvatar from 'src/components/reusable/user-avatar/UserAvatar';
 import { cancelAppointment as resetAppointmentInfo } from 'src/redux/slices/appointmentSlice';
 import { resetAllInfo } from 'src/redux/slices/healthQuestionnaireSlice';
 
+import { zonedTimeToUtc } from 'date-fns-tz';
 import { CONFIRM_NOTE_MAX_LENGTH } from './constants';
 import {
   Container,
@@ -71,12 +72,12 @@ export default function ConfirmAppointment({ onBack }: { onBack: () => void }): 
         capabilityNote: healthQuestionnaire.notes.CAPABILITIES,
         startDate:
           appointment.appointmentType === Appointment.oneTime
-            ? appointment.oneTimeDate.startTime
-            : appointment.recurringDate.startDate,
+            ? zonedTimeToUtc(appointment.oneTimeDate.startTime as Date, location.timezone)
+            : zonedTimeToUtc(appointment.recurringDate.startDate as Date, location.timezone),
         endDate:
           appointment.appointmentType === Appointment.oneTime
-            ? appointment.oneTimeDate.endTime
-            : appointment.recurringDate.endDate,
+            ? zonedTimeToUtc(appointment.oneTimeDate.endTime as Date, location.timezone)
+            : zonedTimeToUtc(appointment.recurringDate.endDate as Date, location.timezone),
         timezone: location.timezone,
         weekdays:
           appointment.appointmentType !== Appointment.oneTime

--- a/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
+++ b/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
@@ -32,6 +32,7 @@ import {
   NotificationMessage,
 } from './styles';
 import { VirtualAssessmentRequestModalProps } from './types';
+import { formatTimeToTimezone } from '../../utils/formatTime';
 
 const decodeToken = (tokenToDecode: string): string => {
   const decoded: { id: string } = jwt_decode(tokenToDecode);
@@ -140,7 +141,12 @@ const VirtualAssessmentRequestModal = ({
             <AppointmentModalBlockParagraph>
               {translate('request_appointment.date_and_time')}
             </AppointmentModalBlockParagraph>
-            {virtualAssessmentTime && format(new Date(virtualAssessmentTime), DRAWER_DATE_FORMAT)}
+            {virtualAssessmentTime &&
+              formatTimeToTimezone(
+                virtualAssessmentTime.toString(),
+                Intl.DateTimeFormat().resolvedOptions().timeZone,
+                DRAWER_DATE_FORMAT
+              )}
           </AppointmentModalBlock>
           {userId === appointment.caregiverInfo.user.id && (
             <AppointmentModalBlock>


### PR DESCRIPTION

## Describe your changes

- Now appointment time displayed with timezone of appointment
- Virtual assessment time applies to current timezone of user
- Time and date values are converted to UTC before sending to backend

![Screenshot from 2024-01-16 17-42-49](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/101258024/a5e304b6-f6d6-478d-a24d-83b7412ff912)

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/jira/software/projects/CC/boards/1?selectedIssue=CC-346)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.