### PR TITLE
fix: Caregiver can't accept an expired VA request

### DIFF
--- a/src/components/caregiver-schedule/CaregiverAppointment.tsx
+++ b/src/components/caregiver-schedule/CaregiverAppointment.tsx
@@ -45,7 +45,7 @@ export default function CaregiverAppointment({ appointmentDays, openDrawer }: Pr
                   <Text>
                     {formatTimeToTimezone(
                       `${appointment.virtualAssessment.assessmentDate} ${appointment.virtualAssessment.startTime}`,
-                      appointment.caregiverInfo.timeZone,
+                      appointment.timezone,
                       DISPLAY_TIME_FORMAT
                     )}
                   </Text>
@@ -53,7 +53,7 @@ export default function CaregiverAppointment({ appointmentDays, openDrawer }: Pr
                   <Text>
                     {formatTimeToTimezone(
                       appointment.startDate,
-                      appointment.caregiverInfo.timeZone,
+                      appointment.timezone,
                       DISPLAY_TIME_FORMAT
                     )}
                   </Text>

--- a/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
+++ b/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
@@ -66,13 +66,6 @@ const VirtualAssessmentRequestModal = ({
 
   const userId = useMemo(() => decodeToken(token), [token]);
 
-  const virtualAssessmentTime =
-    appointment.virtualAssessment &&
-    setCustomTime(
-      appointment.virtualAssessment.assessmentDate,
-      appointment.virtualAssessment.startTime.slice(0, -3)
-    );
-
   const copyMeetingLink = (): void => {
     if (!appointment.virtualAssessment) return;
     const { meetingLink } = appointment.virtualAssessment;
@@ -146,10 +139,10 @@ const VirtualAssessmentRequestModal = ({
             <AppointmentModalBlockParagraph>
               {translate('request_appointment.date_and_time')}
             </AppointmentModalBlockParagraph>
-            {virtualAssessmentTime &&
+            {appointment.virtualAssessment &&
               formatTimeToTimezone(
-                virtualAssessmentTime.toString(),
-                Intl.DateTimeFormat().resolvedOptions().timeZone,
+                `${appointment.virtualAssessment.assessmentDate} ${appointment.virtualAssessment.startTime}`,
+                appointment.timezone,
                 DRAWER_DATE_FORMAT
               )}
           </AppointmentModalBlock>
@@ -190,7 +183,18 @@ const VirtualAssessmentRequestModal = ({
                     variant="outlined"
                     color="primary"
                     fullWidth
-                    disabled={new Date(appointment.startDate) < CURRENT_DAY}
+                    disabled={
+                      formatTimeToTimezone(
+                        appointment.startDate,
+                        appointment.timezone,
+                        DRAWER_DATE_FORMAT
+                      ) <
+                      formatTimeToTimezone(
+                        CURRENT_DAY.toString(),
+                        appointment.timezone,
+                        DRAWER_DATE_FORMAT
+                      )
+                    }
                     onClick={openReschedulingModal}
                   >
                     {translate('request_appointment.btns.reschedule')}
@@ -198,8 +202,26 @@ const VirtualAssessmentRequestModal = ({
                   <FilledButton
                     fullWidth
                     disabled={
-                      new Date(appointment.startDate) < CURRENT_DAY ||
-                      new Date(appointment.virtualAssessment.assessmentDate) < CURRENT_DAY
+                      formatTimeToTimezone(
+                        appointment.startDate,
+                        appointment.timezone,
+                        DRAWER_DATE_FORMAT
+                      ) <
+                        formatTimeToTimezone(
+                          CURRENT_DAY.toString(),
+                          appointment.timezone,
+                          DRAWER_DATE_FORMAT
+                        ) ||
+                      formatTimeToTimezone(
+                        appointment.virtualAssessment.assessmentDate.toString(),
+                        appointment.timezone,
+                        DRAWER_DATE_FORMAT
+                      ) <
+                        formatTimeToTimezone(
+                          CURRENT_DAY.toString(),
+                          appointment.timezone,
+                          DRAWER_DATE_FORMAT
+                        )
                     }
                     onClick={async (): Promise<void> => {
                       await handleStatusChange(VIRTUAL_ASSESSMENT_STATUS.Accepted);

--- a/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
+++ b/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
@@ -13,7 +13,12 @@ import { AssessmentPurpose } from 'src/components/appointments/virtual-assessmen
 import UserAvatar from 'src/components/reusable/user-avatar/UserAvatar';
 import { FilledButton } from 'src/components/reusable';
 import FlowHeader from 'src/components/reusable/header/FlowHeader';
-import { SMALL_AVATAR_SIZE, USER_ROLE, VIRTUAL_ASSESSMENT_STATUS } from 'src/constants';
+import {
+  CURRENT_DAY,
+  SMALL_AVATAR_SIZE,
+  USER_ROLE,
+  VIRTUAL_ASSESSMENT_STATUS,
+} from 'src/constants';
 import { useLocales } from 'src/locales';
 import { virtualAssessmentApi } from 'src/redux/api/virtualAssessmentApi';
 import { useTypedSelector } from 'src/redux/store';
@@ -185,12 +190,17 @@ const VirtualAssessmentRequestModal = ({
                     variant="outlined"
                     color="primary"
                     fullWidth
+                    disabled={new Date(appointment.startDate) < CURRENT_DAY}
                     onClick={openReschedulingModal}
                   >
                     {translate('request_appointment.btns.reschedule')}
                   </Button>
                   <FilledButton
                     fullWidth
+                    disabled={
+                      new Date(appointment.startDate) < CURRENT_DAY ||
+                      new Date(appointment.virtualAssessment.assessmentDate) < CURRENT_DAY
+                    }
                     onClick={async (): Promise<void> => {
                       await handleStatusChange(VIRTUAL_ASSESSMENT_STATUS.Accepted);
                     }}


### PR DESCRIPTION
## Describe your changes

- Caregiver can't accept an expired virtual assessment request.
- if VA date is expired, but appointment start date is not, accept VA button is disabled and reschedule button is active.
- if VA date and appointment start date are expired and appointment status is still Virtual Assesment, both buttons are disabled.
- I check this dates every 15 minutes

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-391)

<img width="138" alt="Снимок экрана 2024-01-20 133040" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/bb0f0362-1804-480c-a86e-7503d9607258">

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.