### PR TITLE
fix: admin delete modal

### DIFF
--- a/src/components/admin-management/AdminManagement.tsx
+++ b/src/components/admin-management/AdminManagement.tsx
@@ -193,11 +193,11 @@ function AdminManagement(): JSX.Element | null {
 
             <Box display="flex" gap={2}>
               <StyledButton variant="contained" onClick={handleDeleteModalToggle}>
-                {translate('adminManagement.no')}
+                {translate('adminManagement.yes')}
               </StyledButton>
 
               <StyledButton variant="contained" color="error" onClick={handleDeleteUser}>
-                {translate('adminManagement.yes')}
+                {translate('adminManagement.no')}
               </StyledButton>
             </Box>
           </Box>

--- a/src/components/user-list/UserList.tsx
+++ b/src/components/user-list/UserList.tsx
@@ -11,6 +11,7 @@ import {
   Pagination,
   Box,
   SelectChangeEvent,
+  Typography,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import FormatLineSpacingIcon from '@mui/icons-material/FormatLineSpacing';
@@ -128,31 +129,41 @@ export default function UserList(): JSX.Element | null {
             {translate('userList.title')}
           </PageName>
         </Stack>
+        <SearchContainer>
+          <OutlinedInput
+            onChange={handleTermSearch}
+            placeholder={translate('userList.search')}
+            startAdornment={
+              <InputAdornment position="start">
+                <SearchIcon />
+              </InputAdornment>
+            }
+            fullWidth
+            size="small"
+          />
+          {sortingOrder === SORT_ORDER.DESC ? (
+            <IconButton size="large" onClick={handleChangeSorting}>
+              <FormatLineSpacingIcon fontSize="large" />
+            </IconButton>
+          ) : (
+            <IconButton size="large" onClick={handleChangeSorting} sx={{ color: PRIMARY.main }}>
+              <FormatLineSpacingIcon fontSize="large" />
+            </IconButton>
+          )}
+        </SearchContainer>
 
-        {isSuccess && users.data.length > 0 ? (
+        {isSuccess && termSearch && users.data.length <= 0 && (
+          <Typography color="GrayText" mt={2}>
+            {translate('no_results_match')}
+          </Typography>
+        )}
+
+        {isSuccess && !termSearch && users.data.length <= 0 && (
+          <PageName>{translate('userList.anyUsers')}</PageName>
+        )}
+
+        {isSuccess && users.data.length > 0 && (
           <>
-            <SearchContainer>
-              <OutlinedInput
-                onChange={handleTermSearch}
-                placeholder={translate('userList.search')}
-                startAdornment={
-                  <InputAdornment position="start">
-                    <SearchIcon />
-                  </InputAdornment>
-                }
-                fullWidth
-                size="small"
-              />
-              {sortingOrder === SORT_ORDER.DESC ? (
-                <IconButton size="large" onClick={handleChangeSorting}>
-                  <FormatLineSpacingIcon fontSize="large" />
-                </IconButton>
-              ) : (
-                <IconButton size="large" onClick={handleChangeSorting} sx={{ color: PRIMARY.main }}>
-                  <FormatLineSpacingIcon fontSize="large" />
-                </IconButton>
-              )}
-            </SearchContainer>
             <StyledStack mt={3}>
               <Table>
                 <TableHead>
@@ -207,8 +218,6 @@ export default function UserList(): JSX.Element | null {
               />
             </Stack>
           </>
-        ) : (
-          <PageName>{translate('userList.anyUsers')}</PageName>
         )}
 
         <Modal
@@ -221,11 +230,11 @@ export default function UserList(): JSX.Element | null {
 
             <Box display="flex" gap={2}>
               <StyledButton variant="contained" onClick={handleDeleteModalToggle}>
-                {translate('adminManagement.no')}
+                {translate('adminManagement.yes')}
               </StyledButton>
 
               <StyledButton variant="contained" color="error" onClick={handleDeleteUser}>
-                {translate('adminManagement.yes')}
+                {translate('adminManagement.no')}
               </StyledButton>
             </Box>
           </Box>

--- a/src/components/user-list/UserList.tsx
+++ b/src/components/user-list/UserList.tsx
@@ -56,6 +56,13 @@ export default function UserList(): JSX.Element | null {
   const [deleteUserId, setDeleteUserId] = useState<string>('');
   const [statusUpdated, setStatusUpdated] = useState<boolean>(false);
   const [userDeleted, setUserDeleted] = useState<boolean>(false);
+  const { currentPage } = router.query;
+
+  useEffect(() => {
+    if (currentPage) {
+      setPage(Number(currentPage));
+    }
+  }, [currentPage]);
 
   const debouncedSearchTerm = useDebounce(termSearch.trim(), DEBOUNCE_DELAY);
 
@@ -196,7 +203,10 @@ export default function UserList(): JSX.Element | null {
                       <StyledTableCell align="right">
                         <IconButton
                           onClick={(): Promise<boolean> =>
-                            router.push(`${ROUTES.adminAccountDetails}${user.id}`)
+                            router.push({
+                              pathname: `${ROUTES.adminAccountDetails}${user.id}`,
+                              query: { page },
+                            })
                           }
                         >
                           <ModeEditOutlineOutlinedIcon />

--- a/src/pages/admin-panel/account-details/[id].tsx
+++ b/src/pages/admin-panel/account-details/[id].tsx
@@ -14,7 +14,7 @@ import { ROUTES } from 'src/routes';
 export default function AccountDetailsPageId(): JSX.Element | null {
   const { translate } = useLocales();
   const router = useRouter();
-  const { id } = router.query;
+  const { id, page } = router.query;
 
   const { data: user, isLoading, isSuccess } = useGetUserInfoQuery(id);
 
@@ -30,7 +30,12 @@ export default function AccountDetailsPageId(): JSX.Element | null {
         <MainWrapper>
           <BackButton
             variant="text"
-            onClick={(): Promise<boolean> => router.push(ROUTES.adminPanel)}
+            onClick={(): Promise<boolean> =>
+              router.push({
+                pathname: `${ROUTES.adminPanel}`,
+                query: { currentPage: page },
+              })
+            }
           >
             <ArrowBackFilled />
             {translate('userList.title')}


### PR DESCRIPTION
## Describe your changes

- fixed delete modal in user list, admin management;
- add text, if users with this search terms are not found;
- if admin goes to edit user profile page from not first page, he is coming back to the same page after.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-398)
- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-401)
- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-402)

<img width="485" alt="Снимок экрана 2024-01-22 122903" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/124cd296-4f5b-4910-a70b-f9c1eb6c8634">
<img width="390" alt="Снимок экрана 2024-01-22 123031" src="https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/b6861df8-e65d-402d-811f-893ecf090d1f">


### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.