### PR TITLE
fix: fixed layout in adming-page, added name column to appointments list

### DIFF
--- a/src/components/account-details/styles.ts
+++ b/src/components/account-details/styles.ts
@@ -94,6 +94,9 @@ export const List = styled('ul')`
   row-gap: 16px;
   width: 100%;
   flex-wrap: wrap;
+  ${({ theme }): string => theme.breakpoints.down('sm')} {
+    gap: 5px;
+  }
 `;
 
 export const Item = styled('li')`

--- a/src/components/admin-appointment-list/AppointmentList.tsx
+++ b/src/components/admin-appointment-list/AppointmentList.tsx
@@ -175,6 +175,7 @@ function AdminAppointmentList(): JSX.Element | null {
                 <TableHead>
                   <TableRow>
                     <TableHeader>{translate('adminAppointmentList.id')}</TableHeader>
+                    <TableHeader>{translate('adminAppointmentList.name')}</TableHeader>
                     <TableHeader>{translate('adminAppointmentList.type')}</TableHeader>
                     <TableHeader>{translate('adminAppointmentList.duration')}</TableHeader>
                     <TableHeader>{translate('adminAppointmentList.creation_date')}</TableHeader>
@@ -193,6 +194,7 @@ function AdminAppointmentList(): JSX.Element | null {
                   {appointments.appointments.map((appointment) => (
                     <TableRow key={appointment.id}>
                       <TableCell>{appointment.id}</TableCell>
+                      <TableCell>{appointment.name}</TableCell>
                       <TableCell>{appointment.type}</TableCell>
                       <TableCell>
                         {calculateDateDifference(appointment.startDate, appointment.endDate)}

--- a/src/components/user-list/styles.ts
+++ b/src/components/user-list/styles.ts
@@ -36,7 +36,7 @@ export const SearchContainer = styled('div')`
 `;
 
 export const StyledStack = styled(Stack)`
-  overflow-x: scroll;
+  overflow-x: auto;
 `;
 
 export const StyledTableRow = styled(TableRow)`

--- a/src/locales/langs/en.ts
+++ b/src/locales/langs/en.ts
@@ -940,6 +940,7 @@ const en = {
     title: 'Appointments',
     search: 'Search',
     id: 'Appointment ID',
+    name: 'Appointment name',
     type: 'Type',
     duration: 'Duration',
     creation_date: 'Date of creation',

--- a/src/pages/admin-panel/admin-management/index.tsx
+++ b/src/pages/admin-panel/admin-management/index.tsx
@@ -15,7 +15,7 @@ export default function AdminManagementPage(): JSX.Element {
       <Head>
         <title>{translate('adminManagement.title')}</title>
       </Head>
-      <AdminPageStyledStack>
+      <AdminPageStyledStack direction="row">
         <AdminMenu />
         <AdminManagement />
       </AdminPageStyledStack>


### PR DESCRIPTION
## Describe your changes

- Fixed layout in admin management page
- Added name column to appointment list
- Adapted account details layout
- Made scroll not visible if unused

![Screenshot from 2024-01-22 13-37-03](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/101258024/4cf358a2-59c6-495e-9a52-d92b4763aa38)

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/jira/software/projects/CC/boards/1?assignee=6257e1835d1e700069af2f1c&selectedIssue=CC-407)
- [Link to JIRA ticket](https://homecareaid.atlassian.net/jira/software/projects/CC/boards/1?assignee=6257e1835d1e700069af2f1c&selectedIssue=CC-404)
- [Link to JIRA ticket](https://homecareaid.atlassian.net/jira/software/projects/CC/boards/1?assignee=6257e1835d1e700069af2f1c&selectedIssue=CC-403)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.