### PR TITLE
fix: add text when admins array is empty

### DIFF
--- a/src/components/admin-management/AdminManagement.tsx
+++ b/src/components/admin-management/AdminManagement.tsx
@@ -10,6 +10,7 @@ import {
   Table,
   TableBody,
   TableHead,
+  Typography,
 } from '@mui/material';
 import { format, parseISO } from 'date-fns';
 import { useRouter } from 'next/router';
@@ -136,72 +137,80 @@ function AdminManagement(): JSX.Element | null {
           size="small"
         />
 
-        <StyledStack mt={3}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableHeader>{translate('adminManagement.name')}</TableHeader>
-                <TableHeader>{translate('adminManagement.email')}</TableHeader>
-                <TableHeader>{translate('adminManagement.typeUser')}</TableHeader>
-                <TableHeader>{translate('adminManagement.phone')}</TableHeader>
-                <TableHeader>{translate('adminManagement.date')}</TableHeader>
-                <TableHeader align="right">{translate('adminManagement.action')}</TableHeader>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {isSuccess &&
-                admins.data.map((admin) => (
-                  <TableRow key={admin.id}>
-                    <TableCell>
-                      {admin.firstName} {admin.lastName}
-                    </TableCell>
-                    <TableCell>{admin.email}</TableCell>
-                    <TableCell>
-                      <GreenSpan>{admin.role}</GreenSpan>
-                    </TableCell>
-                    <TableCell>{admin.phoneNumber}</TableCell>
-                    <TableCell>{format(parseISO(admin.updatedAt), DATE_FORMAT)}</TableCell>
-                    <TableCell align="right">
-                      <IconButton onClick={(): void => handleEditAdminClick(admin.id)}>
-                        <ModeEditOutlineOutlinedIcon />
-                      </IconButton>
-                      <IconButton onClick={(): void => handleCloseModalAndSetUserId(admin.id)}>
-                        <DeleteForeverOutlinedIcon />
-                      </IconButton>
-                    </TableCell>
+        {isSuccess && termSearch && !admins.data.length && (
+          <Typography color="GrayText" mt={2}>
+            {translate('no_results_match')}
+          </Typography>
+        )}
+
+        {isSuccess && admins.data.length > 0 && (
+          <>
+            <StyledStack mt={3}>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableHeader>{translate('adminManagement.name')}</TableHeader>
+                    <TableHeader>{translate('adminManagement.email')}</TableHeader>
+                    <TableHeader>{translate('adminManagement.typeUser')}</TableHeader>
+                    <TableHeader>{translate('adminManagement.phone')}</TableHeader>
+                    <TableHeader>{translate('adminManagement.date')}</TableHeader>
+                    <TableHeader align="right">{translate('adminManagement.action')}</TableHeader>
                   </TableRow>
-                ))}
-            </TableBody>
-          </Table>
-        </StyledStack>
+                </TableHead>
+                <TableBody>
+                  {isSuccess &&
+                    admins.data.map((admin) => (
+                      <TableRow key={admin.id}>
+                        <TableCell>
+                          {admin.firstName} {admin.lastName}
+                        </TableCell>
+                        <TableCell>{admin.email}</TableCell>
+                        <TableCell>
+                          <GreenSpan>{admin.role}</GreenSpan>
+                        </TableCell>
+                        <TableCell>{admin.phoneNumber}</TableCell>
+                        <TableCell>{format(parseISO(admin.updatedAt), DATE_FORMAT)}</TableCell>
+                        <TableCell align="right">
+                          <IconButton onClick={(): void => handleEditAdminClick(admin.id)}>
+                            <ModeEditOutlineOutlinedIcon />
+                          </IconButton>
+                          <IconButton onClick={(): void => handleCloseModalAndSetUserId(admin.id)}>
+                            <DeleteForeverOutlinedIcon />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                </TableBody>
+              </Table>
+            </StyledStack>
+            <Stack display="flex" direction="row" justifyContent="center" mt={2}>
+              <Pagination
+                count={Math.ceil(admins!.count / PAGINATION_ADMINS_LIMIT)}
+                page={page}
+                onChange={handlePageChange}
+              />
+            </Stack>
+            <Modal
+              isActive={isDeleteModalActive}
+              onClose={handleDeleteModalToggle}
+              title={translate('adminManagement.deleteUser')}
+            >
+              <Box display="flex" flexDirection="column">
+                <Title>{translate('adminManagement.deleteWarning')}</Title>
 
-        <Stack display="flex" direction="row" justifyContent="center" mt={2}>
-          <Pagination
-            count={Math.ceil(admins!.count / PAGINATION_ADMINS_LIMIT)}
-            page={page}
-            onChange={handlePageChange}
-          />
-        </Stack>
+                <Box display="flex" gap={2}>
+                  <StyledButton variant="contained" onClick={handleDeleteModalToggle}>
+                    {translate('adminManagement.no')}
+                  </StyledButton>
 
-        <Modal
-          isActive={isDeleteModalActive}
-          onClose={handleDeleteModalToggle}
-          title={translate('adminManagement.deleteUser')}
-        >
-          <Box display="flex" flexDirection="column">
-            <Title>{translate('adminManagement.deleteWarning')}</Title>
-
-            <Box display="flex" gap={2}>
-              <StyledButton variant="contained" onClick={handleDeleteModalToggle}>
-                {translate('adminManagement.no')}
-              </StyledButton>
-
-              <StyledButton variant="contained" color="error" onClick={handleDeleteUser}>
-                {translate('adminManagement.yes')}
-              </StyledButton>
-            </Box>
-          </Box>
-        </Modal>
+                  <StyledButton variant="contained" color="error" onClick={handleDeleteUser}>
+                    {translate('adminManagement.yes')}
+                  </StyledButton>
+                </Box>
+              </Box>
+            </Modal>
+          </>
+        )}
       </ManagementWrapper>
       <UpdateSuccess
         dataUpdated={userDeleted}


### PR DESCRIPTION
## Describe your changes

- I added text when the admins array is empty.

![image](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/92392661/a4406ed6-0e14-4cc9-9ac5-8e4bb5d3b401)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.