### PR TITLE
fix: fixed error which led to displaying wrong time for VA

### DIFF
--- a/src/components/caregiver-schedule/CaregiverAppointment.tsx
+++ b/src/components/caregiver-schedule/CaregiverAppointment.tsx
@@ -3,7 +3,7 @@ import AccessTimeIcon from 'src/assets/icons/AccessTimeIcon';
 import AppointmentStatus from 'src/components/appointments/appointment-status/AppointmentStatus';
 import { APPOINTMENT_STATUS, DISPLAY_TIME_FORMAT, TINY_AVATAR_SIZE } from 'src/constants';
 import { useLocales } from 'src/locales';
-import { formatTimeToTimezone } from 'src/utils/formatTime';
+import { formatTimeToTimezone, formatUTCToTimezone } from 'src/utils/formatTime';
 import {
   AppointmentDetails,
   AppointmentHeader,
@@ -43,9 +43,8 @@ export default function CaregiverAppointment({ appointmentDays, openDrawer }: Pr
                 {appointment.status === APPOINTMENT_STATUS.Virtual &&
                 appointment.virtualAssessment ? (
                   <Text>
-                    {formatTimeToTimezone(
+                    {formatUTCToTimezone(
                       `${appointment.virtualAssessment.assessmentDate} ${appointment.virtualAssessment.startTime}`,
-                      appointment.timezone,
                       DISPLAY_TIME_FORMAT
                     )}
                   </Text>

--- a/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
+++ b/src/components/virtual-assessment-request/VirtualAssessmentRequest.tsx
@@ -38,7 +38,7 @@ import {
   NotificationMessage,
 } from './styles';
 import { VirtualAssessmentRequestModalProps } from './types';
-import { formatTimeToTimezone } from '../../utils/formatTime';
+import { formatUTCToTimezone } from '../../utils/formatTime';
 
 const decodeToken = (tokenToDecode: string): string => {
   const decoded: { id: string } = jwt_decode(tokenToDecode);
@@ -141,9 +141,9 @@ const VirtualAssessmentRequestModal = ({
               {translate('request_appointment.date_and_time')}
             </AppointmentModalBlockParagraph>
             {appointment.virtualAssessment &&
-              formatTimeToTimezone(
+              formatUTCToTimezone(
                 `${appointment.virtualAssessment.assessmentDate} ${appointment.virtualAssessment.startTime}`,
-                TIMEZONE_FORMAT,
+
                 DRAWER_DATE_FORMAT
               )}
           </AppointmentModalBlock>

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,5 +1,6 @@
 import { format, getTime, formatDistanceToNow } from 'date-fns';
-import { utcToZonedTime, format as formatTz } from 'date-fns-tz';
+import { utcToZonedTime, format as formatTz, zonedTimeToUtc } from 'date-fns-tz';
+import { UTC_TIMEZONE } from 'src/constants';
 // ----------------------------------------------------------------------
 
 type InputValue = Date | string | number | null;
@@ -34,7 +35,6 @@ export function fToNow(date: InputValue) {
 //  @param targetTimezone - 'America/New_York'
 //  @param timeFormat - 'yyyy-MM-dd HH:mm:ss'
 //  @return - '2023-12-14 12:00:00'
-
 export function formatTimeToTimezone(
   dateTime: string,
   targetTimezone: string,
@@ -46,6 +46,15 @@ export function formatTimeToTimezone(
   const formattedDateTime = formatTz(adjustedDateTime, timeFormat, {
     timeZone: targetTimezone,
   });
+
+  return formattedDateTime;
+}
+
+export function formatUTCToTimezone(dateTime: string, timeFormat: string): string {
+  const inputDateTime = new Date(dateTime);
+  const adjustedDateTime = zonedTimeToUtc(inputDateTime, UTC_TIMEZONE);
+
+  const formattedDateTime = formatTz(adjustedDateTime, timeFormat);
 
   return formattedDateTime;
 }

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -50,6 +50,10 @@ export function formatTimeToTimezone(
   return formattedDateTime;
 }
 
+// function to format UTC time to specified timezone and time format
+// @param dateTime - '2023-12-14T18:00:00.000Z'
+// @param timeFormat - 'yyyy-MM-dd HH:mm:ss'
+// @return - '2023-12-14 12:00:00'
 export function formatUTCToTimezone(dateTime: string, timeFormat: string): string {
   const inputDateTime = new Date(dateTime);
   const adjustedDateTime = zonedTimeToUtc(inputDateTime, UTC_TIMEZONE);


### PR DESCRIPTION
## Describe your changes

- Fixed bug which led to showing wrong time of virtual assessment (previously user had virtual assessment not in the time he planned to have it)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.