### PR TITLE
fix: signing contract date

### DIFF
--- a/src/components/appointments/agreement-modal/AgreementModal.tsx
+++ b/src/components/appointments/agreement-modal/AgreementModal.tsx
@@ -1,5 +1,7 @@
+import { format, parseISO } from 'date-fns';
+
 import { useLocales } from 'src/locales';
-import { APPOINTMENT_TYPE } from 'src/constants';
+import { APPOINTMENT_STATUS, APPOINTMENT_TYPE, DATE_FORMAT } from 'src/constants';
 
 import { DetailedAppointment } from 'src/redux/api/appointmentApi';
 import {
@@ -32,7 +34,14 @@ export default function AgreementModal({ appointment }: IProps): JSX.Element | n
         <SubTitle>{translate('appointments_page.terms.term_of_agreement_title')}</SubTitle>
         <Text>
           {translate('appointments_page.terms.term_of_agreement_text1')}
-          <Span>{CURRENT_DATE}</Span>
+          {appointment.status !==
+            (APPOINTMENT_STATUS.Virtual ||
+              APPOINTMENT_STATUS.SignedCaregiver ||
+              APPOINTMENT_STATUS.SignedSeeker) && appointment.signingDate ? (
+            <Span>{format(parseISO(appointment.signingDate), DATE_FORMAT)}</Span>
+          ) : (
+            <Span>{CURRENT_DATE}</Span>
+          )}
           {translate('appointments_page.terms.term_of_agreement_text2')}
         </Text>
       </div>


### PR DESCRIPTION
## Describe your changes

- if appointment status is VA, show in Contract current date, else - show sighning contract date

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://homecareaid.atlassian.net/browse/CC-435)

![Снимок экрана 2024-02-02 143409](https://github.com/ZenBit-Tech/ctrlchamps_fe/assets/117380986/e2db0476-8ed6-471e-97c0-e9f5bcf58d10)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
